### PR TITLE
don't throw errors on successful http requests

### DIFF
--- a/src/js/lib/ajax.js
+++ b/src/js/lib/ajax.js
@@ -92,7 +92,8 @@ var ajax = function(opt, success, failure) {
   req.onreadystatechange = function(e) {
     if (req.readyState === 4) {
       var body = req.responseText;
-      var okay = req.status === 200;
+      var okay = req.status >= 200 && req.status < 300 || req.status === 304;
+
       try {
         if (opt.type === 'json') {
           body = JSON.parse(body);


### PR DESCRIPTION
handle http responses that have a good response code as success. similar to https://github.com/jquery/jquery/blob/master/src/ajax.js#L680
