### PR TITLE
Add support for embedded configuration pages

### DIFF
--- a/src/js/settings/settings.js
+++ b/src/js/settings/settings.js
@@ -29,15 +29,7 @@ Settings.reset = function() {
   };
 };
 
-var toHttpUrl = function(url) {
-  if (typeof url === 'string' && url.length && !url.match(/^(\w+:)?\/\//)) {
-    url = 'http://' + url;
-  }
-  return url;
-};
-
 Settings.mainScriptUrl = function(scriptUrl) {
-  scriptUrl = toHttpUrl(scriptUrl);
   if (scriptUrl) {
     localStorage.setItem('mainJsUrl', scriptUrl);
   } else {
@@ -111,7 +103,6 @@ Settings.config = function(opt, open, close) {
   if (typeof opt === 'string') {
     opt = { url: opt };
   }
-  opt.url = toHttpUrl(opt.url);
   if (close === undefined) {
     close = open;
     open = util2.noop;


### PR DESCRIPTION
By allowing a url of the type: 

```
var settingsUrl = 'data:text/html,' + encodeURI(html);
```

It will be possible to have embedded configuration pages instead of having to do a round trip to the internet...

This commit removed the adding of 'http' before url and assumes user will add a correct url to settings as specified in documentation.
