### PR TITLE
Add colors

### DIFF
--- a/src/js/ui/card.js
+++ b/src/js/ui/card.js
@@ -57,6 +57,7 @@ var actionProps = [
 
 var configProps = [
   'style',
+  'backgroundColor'
 ];
 
 var accessorProps = textProps.concat(imageProps).concat(configProps);

--- a/src/js/ui/menu.js
+++ b/src/js/ui/menu.js
@@ -5,8 +5,12 @@ var WindowStack = require('ui/windowstack');
 var Window = require('ui/window');
 var simply = require('ui/simply');
 
+var defaults = {
+  backgroundColor: 'white',
+};
+
 var Menu = function(menuDef) {
-  Window.call(this, menuDef);
+  Window.call(this, myutil.shadow(defaults, menuDef || {}));
   this._dynamic = false;
   this._sections = {};
   this._selection = { sectionIndex: 0, itemIndex: 0 };

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -944,7 +944,7 @@ SimplyPebble.card = function(def, clear, pushing) {
   if (clear !== undefined) {
     SimplyPebble.cardClear(clear);
   }
-  SimplyPebble.windowProps(def, 'white');
+  SimplyPebble.windowProps(def);
   if (def.action !== undefined) {
     SimplyPebble.windowActionBar(def.action);
   }

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -498,6 +498,7 @@ var MenuClearSectionPacket = new struct([
 var MenuPropsPacket = new struct([
   [Packet, 'packet'],
   ['uint16', 'sections', EnumerableType],
+  ['uint8', 'backgroundColor', Color]
 ]);
 
 var MenuSectionPacket = new struct([

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -69,13 +69,76 @@ var SizeType = function(x) {
   this.sizeH(x.y);
 };
 
-var Color = function(x) {
-  switch (x) {
-    case 'clear': return 0x00;
-    case 'black': return 0xC0;
-    case 'white': return 0xFF;
-  }
-  return Number(x);
+var colorMap = {
+    'clear': 0x00,
+    'black': 0xC0,
+    'oxfordBlue': 0xC1,
+    'dukeBlue': 0xC2,
+    'blue': 0xC3,
+    'darkGreen': 0xC4,
+    'midnightGreen': 0xC5,
+    'colbaltBlue': 0xC6,
+    'blueMoon': 0xC7,
+    'islamicGreen': 0xC8,
+    'jaegerGreen': 0xC9,
+    'tiffanyBlue': 0xCA,
+    'vividCerulean': 0xCB,
+    'green': 0xCC,
+    'malachite': 0xCD,
+    'mediumSpringGreen': 0xCE,
+    'cyan': 0xCF,
+    'bulgarianRose': 0xD0,
+    'imperialPurple': 0xD1,
+    'indigo': 0xD2,
+    'electricUltramarine': 0xD3,
+    'armyGreen': 0xD4,
+    'darkGray': 0xD5,
+    'liberty': 0xD6,
+    'veryLightBlue': 0xD7,
+    'kellyGreen': 0xD8,
+    'mayGreen': 0xD9,
+    'cadetBlue': 0xDA,
+    'pictonBlue': 0xDB,
+    'brightGreen': 0xDC,
+    'screaminGreen': 0xDD,
+    'mediumAquamarine': 0xDE,
+    'electricBlue': 0xDF,
+    'darkCandyAppleRed': 0xE0,
+    'jazzberryJam': 0xE1,
+    'purple': 0xE2,
+    'vividViolet': 0xE3,
+    'windsorTan': 0xE4,
+    'roseVale': 0xE5,
+    'purpureus': 0xE6,
+    'lavenderIndigo': 0xE7,
+    'limerick': 0xE8,
+    'brass': 0xE9,
+    'lightGray': 0xEA,
+    'babyBlueEyes': 0xEB,
+    'springBud': 0xEC,
+    'inchworm': 0xED,
+    'mintGreen': 0xEE,
+    'celeste': 0xEF,
+    'red': 0xF0,
+    'folly': 0xF1,
+    'fashionMagenta': 0xF2,
+    'magenta': 0xF3,
+    'orange': 0xF4,
+    'sunsetOrange': 0xF5,
+    'brilliantRose': 0xF6,
+    'shockingPink': 0xF7,
+    'chromeYellow': 0xF8,
+    'rajah': 0xF9,
+    'melon': 0xFA,
+    'richBrilliantLavender': 0xFB,
+    'yellow': 0xFC,
+    'icterine': 0xFD,
+    'pastelYellow': 0xFE,
+    'white': 0xFF
+};
+
+var Color = function(color) {
+  return colorMap[color] ? colorMap[color] : colorMap['clear'];
 };
 
 var Font = function(x) {

--- a/src/simply/simply_menu.c
+++ b/src/simply/simply_menu.c
@@ -31,6 +31,7 @@ typedef struct MenuPropsPacket MenuPropsPacket;
 struct __attribute__((__packed__)) MenuPropsPacket {
   Packet packet;
   uint16_t num_sections;
+  GColor8 background_color;
 };
 
 typedef struct MenuSectionPacket MenuSectionPacket;
@@ -407,6 +408,9 @@ static void handle_menu_clear_section_packet(Simply *simply, Packet *data) {
 static void handle_menu_props_packet(Simply *simply, Packet *data) {
   MenuPropsPacket *packet = (MenuPropsPacket*) data;
   simply_menu_set_num_sections(simply->menu, packet->num_sections);
+  #ifdef PBL_COLOR
+    window_set_background_color(simply->menu->window.window, GColor8Get(packet->background_color));
+  #endif
 }
 
 static void handle_menu_section_packet(Simply *simply, Packet *data) {

--- a/src/simply/simply_ui.c
+++ b/src/simply/simply_ui.c
@@ -222,6 +222,7 @@ static void layer_update_callback(Layer *layer, GContext *ctx) {
     }
   }
 
+  #ifndef PBL_COLOR
   graphics_context_set_fill_color(ctx, GColorBlack);
   graphics_fill_rect(ctx, frame, 0, GCornerNone);
 
@@ -229,6 +230,10 @@ static void layer_update_callback(Layer *layer, GContext *ctx) {
     graphics_context_set_fill_color(ctx, GColorWhite);
     graphics_fill_rect(ctx, frame, 4, GCornersAll);
   }
+  #else
+  graphics_context_set_fill_color(ctx, GColor8Get(self->window.background_color));
+  graphics_fill_rect(ctx, frame, 4, GCornersAll);
+  #endif
 
   if (title_icon) {
     GRect icon_frame = (GRect) {


### PR DESCRIPTION
Hi there, I noticed pebblejs didn't have any color support so I added all the definitions in JS.
This pull request will support colors in all Elements and backgroundColor for Window types.
I've tested this out on both aplite and basalt and seems to work fine.