### PR TITLE
Fix a bug preventing the deletion of items from the localStorage

### DIFF
--- a/src/js/settings/settings.js
+++ b/src/js/settings/settings.js
@@ -106,12 +106,10 @@ var makeDataAccessor = function(type, path) {
     }
     if (typeof field !== 'object' && value === undefined || value === null) {
       delete data[field];
-      return;
     }
     var def = myutil.toObject(field, value);
     util2.copy(def, data);
     Settings._saveData(path, type);
-    return value;
   };
 };
 


### PR DESCRIPTION
The first `return` prevent the saving over the localStorage.
The second `return` is not needed.