### PR TITLE
Add missing documentation comments

### DIFF
--- a/src/js/simply/simply.js
+++ b/src/js/simply/simply.js
@@ -15,6 +15,21 @@ var Vibe = require('ui/vibe');
 
 var simply = {};
 
+/**
+ * The text definition parameter for {@link simply.text}.
+ * @typedef {object} simply.textDef
+ * @property {string} [title] - A new title for the first and largest text field.
+ * @property {string} [subtitle] - A new subtitle for the second large text field.
+ * @property {string} [body] - A new body for the last text field meant to display large bodies of text.
+ */
+/**
+ * Sets a group of text fields at once.
+ * For example, passing a text definition { title: 'A', subtitle: 'B', body: 'C' }
+ * will set the title, subtitle, and body simultaneously. Not all fields need to be specified.
+ * When setting a single field, consider using the specific text setters simply.title, simply.subtitle, simply.body.
+ * @memberOf simply
+ * @param {simply.textDef} textDef - An object defining new text values.
+ */
 simply.text = function(textDef) {
   var wind = WindowStack.top();
   if (!wind || !(wind instanceof Card)) {


### PR DESCRIPTION
Add the missing documentation comments from http://simplyjs.io/doc/ for `simply.text`.