### PR TITLE
Ability to enter in hex color codes w/ rounding

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -12,7 +12,7 @@ var main = new UI.Card({
   icon: 'images/menu_icon.png',
   subtitle: 'Hello World!',
   body: 'Press any button.',
-  titleColor: 'indigo', //named colors
+  titleColor: 'indigo', // Named colors
   bodyColor: '#9a0036' // Hex colors
 });
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -11,7 +11,9 @@ var main = new UI.Card({
   title: 'Pebble.js',
   icon: 'images/menu_icon.png',
   subtitle: 'Hello World!',
-  body: 'Press any button.'
+  body: 'Press any button.',
+  titleColor: 'indigo', //named colors
+  bodyColor: '#6699FF' // Hex colors
 });
 
 main.show();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -13,7 +13,7 @@ var main = new UI.Card({
   subtitle: 'Hello World!',
   body: 'Press any button.',
   titleColor: 'indigo', //named colors
-  bodyColor: '#6699FF' // Hex colors
+  bodyColor: '#9a0036' // Hex colors
 });
 
 main.show();

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -225,9 +225,9 @@ var Color = function(color) {
 var pebbleColors = [0x00, 0x55, 0xAA, 0xFF];
 
 var roundColor = function (color) {
-  var rHex = color.substr(1,2);
-  var gHex = color.substr(3,2);
-  var bHex = color.substr(5,2);
+  var rHex = color.substr(1, 2);
+  var gHex = color.substr(3, 2);
+  var bHex = color.substr(5, 2);
   var r = findClosestColor(rHex, pebbleColors);
   var g = findClosestColor(gHex, pebbleColors);
   var b = findClosestColor(bHex, pebbleColors);

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -235,16 +235,16 @@ var roundColor = function (color) {
 };
 
 var findClosestColor = function(color, colors) {
-    var nearestDist = Infinity;
-    var result = color;
-    colors.forEach(function(col) {
-      var dist = Math.abs(parseInt(color, 16) - col);
-      if (dist < nearestDist) {
-        nearestDist = dist;
-        result = col;
-      }
-    });
-    return result;
+  var nearestDist = Infinity;
+  var result = color;
+  colors.forEach(function(col) {
+    var dist = Math.abs(parseInt(color, 16) - col);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      result = col;
+    }
+  });
+ return result;
 };
 
 var Font = function(x) {

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -244,7 +244,7 @@ var findClosestColor = function(color, colors) {
       result = col;
     }
   });
- return result;
+  return result;
 };
 
 var Font = function(x) {

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -208,66 +208,42 @@ var namedColorMap = {
 
 var Color = function(color) {
   if (color.charAt(0)=='#') {
+      //Convert full hex to shorthand
+      if (color.length==4){
+          var r = color.charAt(1);
+          var g = color.charAt(2);
+          var b = color.charAt(3);
+          color = '#'+r+r+g+g+b+b;
+      }
+      //Ensure upper case
       color = color.toUpperCase();
-      return hexColorMap[findClosestColor(color)];
+      return hexColorMap[roundColor(color)];
   }
   return namedColorMap[color] ? namedColorMap[color] : namedColorMap.clear;
 };
 
-//As seen in: http://stackoverflow.com/questions/4057475/rounding-colour-values-to-the-nearest-of-a-small-set-of-colours
-var findClosestColor = function getSimilarColors (color) {
-    var pebble_colors=Object.keys(hexColorMap);
-
-    //Convert to RGB, then R, G, B
-    var color_rgb = hex2rgb(color);
-    var color_r = color_rgb.split(',')[0];
-    var color_g = color_rgb.split(',')[1];
-    var color_b = color_rgb.split(',')[2];
-
-    //Create an empty array for the difference between the colors
-    var differenceArray=[];
-
-    //Function to find the smallest value in an array
-    Array.min = function( array ){
-        return Math.min.apply( Math, array );
+var roundColor = function (color) {
+    var closestTo = function(color, colors) {
+        var dist = Infinity;
+        var result = color;
+        colors.forEach(function(col) {
+            var localdist = Math.abs(parseInt(color, 16)-parseInt(col, 16));
+            if (localdist < dist) {
+                dist = localdist;
+                result = col;
+            }
+        });
+        return result;
     };
 
-    //Convert the HEX color in the array to RGB colors, split them up to R-G-B, then find out the difference between the "color" and the colors in the array
-    pebble_colors.forEach(function(pebble_color) {
-        var base_color_rgb = hex2rgb(pebble_color);
-        var base_colors_r = base_color_rgb.split(',')[0];
-        var base_colors_g = base_color_rgb.split(',')[1];
-        var base_colors_b = base_color_rgb.split(',')[2];
-
-        //Add the difference to the differenceArray
-        differenceArray.push(Math.sqrt((color_r-base_colors_r)*(color_r-base_colors_r)+(color_g-base_colors_g)*(color_g-base_colors_g)+(color_b-base_colors_b)*(color_b-base_colors_b)));
-    });
-
-    //Get the lowest number from the differenceArray
-    var lowest = Array.min(differenceArray);
-
-    //Get the index for that lowest number
-    var index = differenceArray.indexOf(lowest);
-
-    //Function to convert HEX to RGB
-    function hex2rgb(colour) {
-        var r,g,b;
-        if ( colour.charAt(0) == '#' ) {
-            colour = colour.substr(1);
-        }
-
-        r = colour.charAt(0) + colour.charAt(1);
-        g = colour.charAt(2) + colour.charAt(3);
-        b = colour.charAt(4) + colour.charAt(5);
-
-        r = parseInt( r,16 );
-        g = parseInt( g,16 );
-        b = parseInt( b ,16);
-        return r+','+g+','+b;
-    }
-
-    //Return the HEX code
-    return pebble_colors[index];
+    var colors = ['00','55','AA','FF'];
+    var r_hex = color.charAt(1) + color.charAt(2);
+    var g_hex = color.charAt(3) + color.charAt(4);
+    var b_hex = color.charAt(5) + color.charAt(6);
+    var r = closestTo(r_hex, colors);
+    var g = closestTo(g_hex, colors);
+    var b = closestTo(b_hex, colors);
+    return '#'+r+g+b;
 };
 
 var Font = function(x) {

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -227,11 +227,11 @@ var roundColor = function (color) {
     var nearestDist = Infinity;
     var result = color;
     colors.forEach(function(col) {
-        var dist = Math.abs(parseInt(color, 16) - parseInt(col, 16));
-        if (dist < nearestDist) {
-            nearestDist = dist;
-            result = col;
-        }
+      var dist = Math.abs(parseInt(color, 16) - parseInt(col, 16));
+      if (dist < nearestDist) {
+        nearestDist = dist;
+        result = col;
+      }
     });
     return result;
   };

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -208,8 +208,8 @@ var namedColorMap = {
 
 var Color = function(color) {
   if (color.charAt(0) === '#') {
-    // Convert full hex to shorthand
-    if (color.length === 4){
+    // Convert shorthand hex to full length for rounding
+    if (color.length === 4) {
       var r = color.charAt(1);
       var g = color.charAt(2);
       var b = color.charAt(3);
@@ -222,28 +222,29 @@ var Color = function(color) {
   return namedColorMap[color] ? namedColorMap[color] : namedColorMap.clear;
 };
 
+var pebbleColors = [0x00, 0x55, 0xAA, 0xFF];
+
 var roundColor = function (color) {
-  var closestTo = function(color, colors) {
+  var rHex = color.substr(1,2);
+  var gHex = color.substr(3,2);
+  var bHex = color.substr(5,2);
+  var r = findClosestColor(rHex, pebbleColors);
+  var g = findClosestColor(gHex, pebbleColors);
+  var b = findClosestColor(bHex, pebbleColors);
+  return '#'+r+g+b;
+};
+
+var findClosestColor = function(color, colors) {
     var nearestDist = Infinity;
     var result = color;
     colors.forEach(function(col) {
-      var dist = Math.abs(parseInt(color, 16) - parseInt(col, 16));
+      var dist = Math.abs(parseInt(color, 16) - col);
       if (dist < nearestDist) {
         nearestDist = dist;
         result = col;
       }
     });
     return result;
-  };
-
-  var colors = ['00', '55', 'AA', 'FF'];
-  var rHex = color.charAt(1) + color.charAt(2);
-  var gHex = color.charAt(3) + color.charAt(4);
-  var bHex = color.charAt(5) + color.charAt(6);
-  var r = closestTo(rHex, colors);
-  var g = closestTo(gHex, colors);
-  var b = closestTo(bHex, colors);
-  return '#'+r+g+b;
 };
 
 var Font = function(x) {

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -70,7 +70,74 @@ var SizeType = function(x) {
   this.sizeH(x.y);
 };
 
-var colorMap = {
+var hexColorMap = {
+    '#000000': 0xC0,
+    '#000055': 0xC1,
+    '#0000AA': 0xC2,
+    '#0000FF': 0xC3,
+    '#005500': 0xC4,
+    '#005555': 0xC5,
+    '#0055AA': 0xC6,
+    '#0055FF': 0xC7,
+    '#00AA00': 0xC8,
+    '#00AA55': 0xC9,
+    '#00AAAA': 0xCA,
+    '#00AAFF': 0xCB,
+    '#00FF00': 0xCC,
+    '#00FF55': 0xCD,
+    '#00FFAA': 0xCE,
+    '#00FFFF': 0xCF,
+    '#550000': 0xD0,
+    '#550055': 0xD1,
+    '#5500AA': 0xD2,
+    '#5500FF': 0xD3,
+    '#555500': 0xD4,
+    '#555555': 0xD5,
+    '#5555AA': 0xD6,
+    '#5555FF': 0xD7,
+    '#55AA00': 0xD8,
+    '#55AA55': 0xD9,
+    '#55AAAA': 0xDA,
+    '#55AAFF': 0xDB,
+    '#55FF00': 0xDC,
+    '#55FF55': 0xDD,
+    '#55FFAA': 0xDE,
+    '#55FFFF': 0xDF,
+    '#AA0000': 0xE0,
+    '#AA0055': 0xE1,
+    '#AA00AA': 0xE2,
+    '#AA00FF': 0xE3,
+    '#AA5500': 0xE4,
+    '#AA5555': 0xE5,
+    '#AA55AA': 0xE6,
+    '#AA55FF': 0xE7,
+    '#AAAA00': 0xE8,
+    '#AAAA55': 0xE9,
+    '#AAAAAA': 0xEA,
+    '#AAAAFF': 0xEB,
+    '#AAFF00': 0xEC,
+    '#AAFF55': 0xED,
+    '#AAFFAA': 0xEE,
+    '#AAFFFF': 0xEF,
+    '#FF0000': 0xF0,
+    '#FF0055': 0xF1,
+    '#FF00AA': 0xF2,
+    '#FF00FF': 0xF3,
+    '#FF5500': 0xF4,
+    '#FF5555': 0xF5,
+    '#FF55AA': 0xF6,
+    '#FF55FF': 0xF7,
+    '#FFAA00': 0xF8,
+    '#FFAA55': 0xF9,
+    '#FFAAAA': 0xFA,
+    '#FFAAFF': 0xFB,
+    '#FFFF00': 0xFC,
+    '#FFFF55': 0xFD,
+    '#FFFFAA': 0xFE,
+    '#FFFFFF': 0xFF,
+};
+
+var namedColorMap = {
     'clear': 0x00,
     'black': 0xC0,
     'oxfordBlue': 0xC1,
@@ -140,7 +207,67 @@ var colorMap = {
 };
 
 var Color = function(color) {
-  return colorMap[color] ? colorMap[color] : colorMap.clear;
+  if (color.charAt(0)=='#') {
+      color = color.toUpperCase();
+      return hexColorMap[findClosestColor(color)];
+  }
+  return namedColorMap[color] ? namedColorMap[color] : namedColorMap.clear;
+};
+
+//As seen in: http://stackoverflow.com/questions/4057475/rounding-colour-values-to-the-nearest-of-a-small-set-of-colours
+var findClosestColor = function getSimilarColors (color) {
+    var pebble_colors=Object.keys(hexColorMap);
+
+    //Convert to RGB, then R, G, B
+    var color_rgb = hex2rgb(color);
+    var color_r = color_rgb.split(',')[0];
+    var color_g = color_rgb.split(',')[1];
+    var color_b = color_rgb.split(',')[2];
+
+    //Create an empty array for the difference between the colors
+    var differenceArray=[];
+
+    //Function to find the smallest value in an array
+    Array.min = function( array ){
+        return Math.min.apply( Math, array );
+    };
+
+    //Convert the HEX color in the array to RGB colors, split them up to R-G-B, then find out the difference between the "color" and the colors in the array
+    pebble_colors.forEach(function(pebble_color) {
+        var base_color_rgb = hex2rgb(pebble_color);
+        var base_colors_r = base_color_rgb.split(',')[0];
+        var base_colors_g = base_color_rgb.split(',')[1];
+        var base_colors_b = base_color_rgb.split(',')[2];
+
+        //Add the difference to the differenceArray
+        differenceArray.push(Math.sqrt((color_r-base_colors_r)*(color_r-base_colors_r)+(color_g-base_colors_g)*(color_g-base_colors_g)+(color_b-base_colors_b)*(color_b-base_colors_b)));
+    });
+
+    //Get the lowest number from the differenceArray
+    var lowest = Array.min(differenceArray);
+
+    //Get the index for that lowest number
+    var index = differenceArray.indexOf(lowest);
+
+    //Function to convert HEX to RGB
+    function hex2rgb(colour) {
+        var r,g,b;
+        if ( colour.charAt(0) == '#' ) {
+            colour = colour.substr(1);
+        }
+
+        r = colour.charAt(0) + colour.charAt(1);
+        g = colour.charAt(2) + colour.charAt(3);
+        b = colour.charAt(4) + colour.charAt(5);
+
+        r = parseInt( r,16 );
+        g = parseInt( g,16 );
+        b = parseInt( b ,16);
+        return r+','+g+','+b;
+    }
+
+    //Return the HEX code
+    return pebble_colors[index];
 };
 
 var Font = function(x) {

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -71,179 +71,179 @@ var SizeType = function(x) {
 };
 
 var hexColorMap = {
-    '#000000': 0xC0,
-    '#000055': 0xC1,
-    '#0000AA': 0xC2,
-    '#0000FF': 0xC3,
-    '#005500': 0xC4,
-    '#005555': 0xC5,
-    '#0055AA': 0xC6,
-    '#0055FF': 0xC7,
-    '#00AA00': 0xC8,
-    '#00AA55': 0xC9,
-    '#00AAAA': 0xCA,
-    '#00AAFF': 0xCB,
-    '#00FF00': 0xCC,
-    '#00FF55': 0xCD,
-    '#00FFAA': 0xCE,
-    '#00FFFF': 0xCF,
-    '#550000': 0xD0,
-    '#550055': 0xD1,
-    '#5500AA': 0xD2,
-    '#5500FF': 0xD3,
-    '#555500': 0xD4,
-    '#555555': 0xD5,
-    '#5555AA': 0xD6,
-    '#5555FF': 0xD7,
-    '#55AA00': 0xD8,
-    '#55AA55': 0xD9,
-    '#55AAAA': 0xDA,
-    '#55AAFF': 0xDB,
-    '#55FF00': 0xDC,
-    '#55FF55': 0xDD,
-    '#55FFAA': 0xDE,
-    '#55FFFF': 0xDF,
-    '#AA0000': 0xE0,
-    '#AA0055': 0xE1,
-    '#AA00AA': 0xE2,
-    '#AA00FF': 0xE3,
-    '#AA5500': 0xE4,
-    '#AA5555': 0xE5,
-    '#AA55AA': 0xE6,
-    '#AA55FF': 0xE7,
-    '#AAAA00': 0xE8,
-    '#AAAA55': 0xE9,
-    '#AAAAAA': 0xEA,
-    '#AAAAFF': 0xEB,
-    '#AAFF00': 0xEC,
-    '#AAFF55': 0xED,
-    '#AAFFAA': 0xEE,
-    '#AAFFFF': 0xEF,
-    '#FF0000': 0xF0,
-    '#FF0055': 0xF1,
-    '#FF00AA': 0xF2,
-    '#FF00FF': 0xF3,
-    '#FF5500': 0xF4,
-    '#FF5555': 0xF5,
-    '#FF55AA': 0xF6,
-    '#FF55FF': 0xF7,
-    '#FFAA00': 0xF8,
-    '#FFAA55': 0xF9,
-    '#FFAAAA': 0xFA,
-    '#FFAAFF': 0xFB,
-    '#FFFF00': 0xFC,
-    '#FFFF55': 0xFD,
-    '#FFFFAA': 0xFE,
-    '#FFFFFF': 0xFF,
+  '#000000': 0xC0,
+  '#000055': 0xC1,
+  '#0000AA': 0xC2,
+  '#0000FF': 0xC3,
+  '#005500': 0xC4,
+  '#005555': 0xC5,
+  '#0055AA': 0xC6,
+  '#0055FF': 0xC7,
+  '#00AA00': 0xC8,
+  '#00AA55': 0xC9,
+  '#00AAAA': 0xCA,
+  '#00AAFF': 0xCB,
+  '#00FF00': 0xCC,
+  '#00FF55': 0xCD,
+  '#00FFAA': 0xCE,
+  '#00FFFF': 0xCF,
+  '#550000': 0xD0,
+  '#550055': 0xD1,
+  '#5500AA': 0xD2,
+  '#5500FF': 0xD3,
+  '#555500': 0xD4,
+  '#555555': 0xD5,
+  '#5555AA': 0xD6,
+  '#5555FF': 0xD7,
+  '#55AA00': 0xD8,
+  '#55AA55': 0xD9,
+  '#55AAAA': 0xDA,
+  '#55AAFF': 0xDB,
+  '#55FF00': 0xDC,
+  '#55FF55': 0xDD,
+  '#55FFAA': 0xDE,
+  '#55FFFF': 0xDF,
+  '#AA0000': 0xE0,
+  '#AA0055': 0xE1,
+  '#AA00AA': 0xE2,
+  '#AA00FF': 0xE3,
+  '#AA5500': 0xE4,
+  '#AA5555': 0xE5,
+  '#AA55AA': 0xE6,
+  '#AA55FF': 0xE7,
+  '#AAAA00': 0xE8,
+  '#AAAA55': 0xE9,
+  '#AAAAAA': 0xEA,
+  '#AAAAFF': 0xEB,
+  '#AAFF00': 0xEC,
+  '#AAFF55': 0xED,
+  '#AAFFAA': 0xEE,
+  '#AAFFFF': 0xEF,
+  '#FF0000': 0xF0,
+  '#FF0055': 0xF1,
+  '#FF00AA': 0xF2,
+  '#FF00FF': 0xF3,
+  '#FF5500': 0xF4,
+  '#FF5555': 0xF5,
+  '#FF55AA': 0xF6,
+  '#FF55FF': 0xF7,
+  '#FFAA00': 0xF8,
+  '#FFAA55': 0xF9,
+  '#FFAAAA': 0xFA,
+  '#FFAAFF': 0xFB,
+  '#FFFF00': 0xFC,
+  '#FFFF55': 0xFD,
+  '#FFFFAA': 0xFE,
+  '#FFFFFF': 0xFF,
 };
 
 var namedColorMap = {
-    'clear': 0x00,
-    'black': 0xC0,
-    'oxfordBlue': 0xC1,
-    'dukeBlue': 0xC2,
-    'blue': 0xC3,
-    'darkGreen': 0xC4,
-    'midnightGreen': 0xC5,
-    'cobaltBlue': 0xC6,
-    'blueMoon': 0xC7,
-    'islamicGreen': 0xC8,
-    'jaegerGreen': 0xC9,
-    'tiffanyBlue': 0xCA,
-    'vividCerulean': 0xCB,
-    'green': 0xCC,
-    'malachite': 0xCD,
-    'mediumSpringGreen': 0xCE,
-    'cyan': 0xCF,
-    'bulgarianRose': 0xD0,
-    'imperialPurple': 0xD1,
-    'indigo': 0xD2,
-    'electricUltramarine': 0xD3,
-    'armyGreen': 0xD4,
-    'darkGray': 0xD5,
-    'liberty': 0xD6,
-    'veryLightBlue': 0xD7,
-    'kellyGreen': 0xD8,
-    'mayGreen': 0xD9,
-    'cadetBlue': 0xDA,
-    'pictonBlue': 0xDB,
-    'brightGreen': 0xDC,
-    'screaminGreen': 0xDD,
-    'mediumAquamarine': 0xDE,
-    'electricBlue': 0xDF,
-    'darkCandyAppleRed': 0xE0,
-    'jazzberryJam': 0xE1,
-    'purple': 0xE2,
-    'vividViolet': 0xE3,
-    'windsorTan': 0xE4,
-    'roseVale': 0xE5,
-    'purpureus': 0xE6,
-    'lavenderIndigo': 0xE7,
-    'limerick': 0xE8,
-    'brass': 0xE9,
-    'lightGray': 0xEA,
-    'babyBlueEyes': 0xEB,
-    'springBud': 0xEC,
-    'inchworm': 0xED,
-    'mintGreen': 0xEE,
-    'celeste': 0xEF,
-    'red': 0xF0,
-    'folly': 0xF1,
-    'fashionMagenta': 0xF2,
-    'magenta': 0xF3,
-    'orange': 0xF4,
-    'sunsetOrange': 0xF5,
-    'brilliantRose': 0xF6,
-    'shockingPink': 0xF7,
-    'chromeYellow': 0xF8,
-    'rajah': 0xF9,
-    'melon': 0xFA,
-    'richBrilliantLavender': 0xFB,
-    'yellow': 0xFC,
-    'icterine': 0xFD,
-    'pastelYellow': 0xFE,
-    'white': 0xFF,
-    'clearWhite': 0x3F,
+  'clear': 0x00,
+  'black': 0xC0,
+  'oxfordBlue': 0xC1,
+  'dukeBlue': 0xC2,
+  'blue': 0xC3,
+  'darkGreen': 0xC4,
+  'midnightGreen': 0xC5,
+  'cobaltBlue': 0xC6,
+  'blueMoon': 0xC7,
+  'islamicGreen': 0xC8,
+  'jaegerGreen': 0xC9,
+  'tiffanyBlue': 0xCA,
+  'vividCerulean': 0xCB,
+  'green': 0xCC,
+  'malachite': 0xCD,
+  'mediumSpringGreen': 0xCE,
+  'cyan': 0xCF,
+  'bulgarianRose': 0xD0,
+  'imperialPurple': 0xD1,
+  'indigo': 0xD2,
+  'electricUltramarine': 0xD3,
+  'armyGreen': 0xD4,
+  'darkGray': 0xD5,
+  'liberty': 0xD6,
+  'veryLightBlue': 0xD7,
+  'kellyGreen': 0xD8,
+  'mayGreen': 0xD9,
+  'cadetBlue': 0xDA,
+  'pictonBlue': 0xDB,
+  'brightGreen': 0xDC,
+  'screaminGreen': 0xDD,
+  'mediumAquamarine': 0xDE,
+  'electricBlue': 0xDF,
+  'darkCandyAppleRed': 0xE0,
+  'jazzberryJam': 0xE1,
+  'purple': 0xE2,
+  'vividViolet': 0xE3,
+  'windsorTan': 0xE4,
+  'roseVale': 0xE5,
+  'purpureus': 0xE6,
+  'lavenderIndigo': 0xE7,
+  'limerick': 0xE8,
+  'brass': 0xE9,
+  'lightGray': 0xEA,
+  'babyBlueEyes': 0xEB,
+  'springBud': 0xEC,
+  'inchworm': 0xED,
+  'mintGreen': 0xEE,
+  'celeste': 0xEF,
+  'red': 0xF0,
+  'folly': 0xF1,
+  'fashionMagenta': 0xF2,
+  'magenta': 0xF3,
+  'orange': 0xF4,
+  'sunsetOrange': 0xF5,
+  'brilliantRose': 0xF6,
+  'shockingPink': 0xF7,
+  'chromeYellow': 0xF8,
+  'rajah': 0xF9,
+  'melon': 0xFA,
+  'richBrilliantLavender': 0xFB,
+  'yellow': 0xFC,
+  'icterine': 0xFD,
+  'pastelYellow': 0xFE,
+  'white': 0xFF,
+  'clearWhite': 0x3F,
 };
 
 var Color = function(color) {
-  if (color.charAt(0)=='#') {
-      //Convert full hex to shorthand
-      if (color.length==4){
-          var r = color.charAt(1);
-          var g = color.charAt(2);
-          var b = color.charAt(3);
-          color = '#'+r+r+g+g+b+b;
-      }
-      //Ensure upper case
-      color = color.toUpperCase();
-      return hexColorMap[roundColor(color)];
+  if (color.charAt(0) === '#') {
+    // Convert full hex to shorthand
+    if (color.length === 4){
+      var r = color.charAt(1);
+      var g = color.charAt(2);
+      var b = color.charAt(3);
+      color = '#'+r+r+g+g+b+b;
+    }
+    // Ensure upper case
+    color = color.toUpperCase();
+    return hexColorMap[roundColor(color)];
   }
   return namedColorMap[color] ? namedColorMap[color] : namedColorMap.clear;
 };
 
 var roundColor = function (color) {
-    var closestTo = function(color, colors) {
-        var dist = Infinity;
-        var result = color;
-        colors.forEach(function(col) {
-            var localdist = Math.abs(parseInt(color, 16)-parseInt(col, 16));
-            if (localdist < dist) {
-                dist = localdist;
-                result = col;
-            }
-        });
-        return result;
-    };
+  var closestTo = function(color, colors) {
+    var nearestDist = Infinity;
+    var result = color;
+    colors.forEach(function(col) {
+        var dist = Math.abs(parseInt(color, 16) - parseInt(col, 16));
+        if (dist < nearestDist) {
+            nearestDist = dist;
+            result = col;
+        }
+    });
+    return result;
+  };
 
-    var colors = ['00','55','AA','FF'];
-    var r_hex = color.charAt(1) + color.charAt(2);
-    var g_hex = color.charAt(3) + color.charAt(4);
-    var b_hex = color.charAt(5) + color.charAt(6);
-    var r = closestTo(r_hex, colors);
-    var g = closestTo(g_hex, colors);
-    var b = closestTo(b_hex, colors);
-    return '#'+r+g+b;
+  var colors = ['00', '55', 'AA', 'FF'];
+  var rHex = color.charAt(1) + color.charAt(2);
+  var gHex = color.charAt(3) + color.charAt(4);
+  var bHex = color.charAt(5) + color.charAt(6);
+  var r = closestTo(rHex, colors);
+  var g = closestTo(gHex, colors);
+  var b = closestTo(bHex, colors);
+  return '#'+r+g+b;
 };
 
 var Font = function(x) {


### PR DESCRIPTION
Enables users to enter hex codes instead of color names for a color parameter. Instead of preventing invalid hex codes, we round them to the nearest Pebble color. 