### PR TITLE
Bugfix basalt window handling

### DIFF
--- a/src/simply/simply_res.c
+++ b/src/simply/simply_res.c
@@ -110,7 +110,7 @@ typedef struct {
   const uint8_t *data;
 } CreateDataContext;
 
-static GBitmap *create_bitmap_with_data(SimplyImage *image, void *data) {
+static GBitmap *SDK_2_USAGE create_bitmap_with_data(SimplyImage *image, void *data) {
   CreateDataContext *ctx = data;
   GBitmap *bitmap = gbitmap_create_blank(ctx->size, GBitmapFormat1Bit);
   if (bitmap) {

--- a/src/simply/simply_res.c
+++ b/src/simply/simply_res.c
@@ -137,8 +137,8 @@ SimplyImage *simply_res_add_image(SimplyRes *self, uint32_t id, int16_t width, i
     .data_length = pixels_length,
     .data = pixels,
   };
-  image = SDK_SELECT(create_image(self, create_bitmap_with_png_data, &context),
-                     create_image(self, create_bitmap_with_data, &context));
+  image = IF_SDK_3_ELSE(create_image(self, create_bitmap_with_png_data, &context),
+                        create_image(self, create_bitmap_with_data, &context));
   if (image) {
     image->id = id;
     add_image(self, image);

--- a/src/simply/simply_window.c
+++ b/src/simply/simply_window.c
@@ -310,6 +310,9 @@ bool simply_window_disappear(SimplyWindow *self) {
 }
 
 void simply_window_unload(SimplyWindow *self) {
+  // Unregister the click config provider
+  window_set_click_config_provider_with_context(self->window, NULL, NULL);
+
   scroll_layer_destroy(self->scroll_layer);
   self->scroll_layer = NULL;
 }

--- a/src/simply/simply_window.h
+++ b/src/simply/simply_window.h
@@ -5,6 +5,7 @@
 #include "simply.h"
 
 #include "util/color.h"
+#include "util/sdk.h"
 #include "util/status_bar_layer.h"
 
 #include <pebble.h>

--- a/src/simply/simply_window_stack.c
+++ b/src/simply/simply_window_stack.c
@@ -115,7 +115,7 @@ static void show_window_sdk_2(SimplyWindowStack *self, SimplyWindow *window, boo
 #endif
 
 void simply_window_stack_show(SimplyWindowStack *self, SimplyWindow *window, bool is_push) {
-  SDK_SELECT(show_window_sdk_3, show_window_sdk_2)(self, window, is_push);
+  IF_SDK_3_ELSE(show_window_sdk_3, show_window_sdk_2)(self, window, is_push);
 }
 
 void simply_window_stack_pop(SimplyWindowStack *self, SimplyWindow *window) {
@@ -142,11 +142,11 @@ void simply_window_stack_send_show(SimplyWindowStack *self, SimplyWindow *window
 void simply_window_stack_send_hide(SimplyWindowStack *self, SimplyWindow *window) {
   if (window->id && !self->is_showing) {
     send_window_hide(self->simply->msg, window->id);
-    SDK_SELECT(NONE, {
+    IF_SDK_2_ELSE({
       if (!self->is_hiding) {
         window_stack_push(self->pusher, false);
       }
-    });
+    }, NULL);
   }
 }
 
@@ -183,9 +183,9 @@ SimplyWindowStack *simply_window_stack_create(Simply *simply) {
   SimplyWindowStack *self = malloc(sizeof(*self));
   *self = (SimplyWindowStack) { .simply = simply };
 
-  SDK_SELECT(NONE, {
+  IF_SDK_2_ELSE({
     self->pusher = window_create();
-  });
+  }, NULL);
 
   return self;
 }
@@ -195,10 +195,10 @@ void simply_window_stack_destroy(SimplyWindowStack *self) {
     return;
   }
 
-  SDK_SELECT(NONE, {
+  IF_SDK_2_ELSE({
     window_destroy(self->pusher);
     self->pusher = NULL;
-  });
+  }, NULL);
 
   free(self);
 }

--- a/src/simply/simply_window_stack.c
+++ b/src/simply/simply_window_stack.c
@@ -84,12 +84,28 @@ SimplyWindow *simply_window_stack_get_top_window(Simply *simply) {
 
 #ifdef PBL_SDK_3
 static void show_window_sdk_3(SimplyWindowStack *self, SimplyWindow *window, bool is_push) {
-  self->is_showing = true;
-  window_stack_pop_all(false);
-  self->is_showing = false;
+  const bool animated = (self->simply->splash == NULL);
+
+  if (!animated) {
+    self->is_showing = true;
+    window_stack_pop_all(false);
+    self->is_showing = false;
+  }
+
+  Window *prev_window = window_stack_get_top_window();
 
   simply_window_preload(window);
-  window_stack_push(window->window, false);
+
+  if (window->window == prev_window) {
+    // It's the same window, we can't animate for now
+    return;
+  }
+
+  window_stack_push(window->window, animated);
+
+  if (animated) {
+    window_stack_remove(prev_window, animated);
+  }
 }
 #endif
 

--- a/src/simply/simply_window_stack.h
+++ b/src/simply/simply_window_stack.h
@@ -14,7 +14,7 @@ typedef struct SimplyWindowStack SimplyWindowStack;
 
 struct SimplyWindowStack {
   Simply *simply;
-  SDK_SELECT(NONE, Window *pusher);
+  IF_SDK_2_ELSE(Window *pusher, NONE);
   bool is_showing:1;
   bool is_hiding:1;
 };

--- a/src/util/sdk.h
+++ b/src/util/sdk.h
@@ -4,6 +4,14 @@
 
 #ifdef PBL_SDK_3
 #define SDK_SELECT(sdk3, sdk2) sdk3
+#define IF_SDK_3_ELSE(sdk3, other) sdk3
+#define IF_SDK_2_ELSE(sdk2, other) other
+#define SDK_3_USAGE
+#define SDK_2_USAGE __attribute__((unused))
 #elif PBL_SDK_2
 #define SDK_SELECT(sdk3, sdk2) sdk2
+#define IF_SDK_3_ELSE(sdk3, other) other
+#define IF_SDK_2_ELSE(sdk2, other) sdk2
+#define SDK_3_USAGE __attribute__((unused))
+#define SDK_2_USAGE
 #endif

--- a/src/util/sdk.h
+++ b/src/util/sdk.h
@@ -3,13 +3,11 @@
 #include "util/none.h"
 
 #ifdef PBL_SDK_3
-#define SDK_SELECT(sdk3, sdk2) sdk3
 #define IF_SDK_3_ELSE(sdk3, other) sdk3
 #define IF_SDK_2_ELSE(sdk2, other) other
 #define SDK_3_USAGE
 #define SDK_2_USAGE __attribute__((unused))
 #elif PBL_SDK_2
-#define SDK_SELECT(sdk3, sdk2) sdk2
 #define IF_SDK_3_ELSE(sdk3, other) other
 #define IF_SDK_2_ELSE(sdk2, other) sdk2
 #define SDK_3_USAGE __attribute__((unused))


### PR DESCRIPTION
I think I may have finally found the minimum ground in which windows will work without crashing on basalt, but I wouldn't be surprised if that's not the case. I'm putting this up so that it gets some testing unlike my previous attempt.

If this works fine without crashing of any combination aplite can already handle, work can proceed with gaining back proper push and pop animations and possibly more efficient memory usage.