### PR TITLE
Add SDK 2.9 travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
 
 env:
+  - PEBBLE_SDK_VERSION=2.9
   - PEBBLE_SDK_VERSION=3.6
 
 before_install:


### PR DESCRIPTION
Pebble.js needs to also be able to build on the older SDK as well.