### PR TITLE
Add window load event

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,20 @@ You can register a handler for the 'up', 'select', 'down', and 'back' buttons.
 
 Just like `Window.on('click', button, handler)` but for 'longClick' events.
 
+#### Window.on('load', handler(GSize))
+
+Registers a handler to call when the window is loaded, identified, and size information is available. This is useful for positioning UI relative to screen boundaries.
+
+````js
+// Define the handler before showing.
+wind.on('load', function(size) {
+  console.log(size.w + 'x' + size.h + ' window loaded!');
+});
+
+// The load event will emit, and the handler will be called.
+wind.show();
+````
+
 #### Window.on('show', handler)
 
 Registers a handler to call when the window is shown. This is useful for knowing when a user returns to your window from another. This event is also emitted when programmatically showing the window. This does not include when a Pebble notification popup is exited, revealing your window.

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -42,14 +42,18 @@ main.on('click', 'select', function(e) {
   var wind = new UI.Window({
     fullscreen: true,
   });
-  var textfield = new UI.Text({
-    position: new Vector2(0, 65),
-    size: new Vector2(144, 30),
-    font: 'gothic-24-bold',
-    text: 'Text Anywhere!',
-    textAlign: 'center'
+  wind.on('load', function(size) {
+    console.log(size.w + 'x' + size.h + ' window loaded!');
+    var textSize = new Vector2(144, 30);
+    var textfield = new UI.Text({
+      position: new Vector2((size.w - textSize.x) / 2, (size.h - textSize.y) / 2),
+      size: textSize,
+      font: 'gothic-24-bold',
+      text: 'Text Centered!',
+      textAlign: 'center'
+    });
+    wind.add(textfield);
   });
-  wind.add(textfield);
   wind.show();
 });
 

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -72,6 +72,21 @@ var SizeType = function(x) {
   this.sizeH(x.y);
 };
 
+var GPoint = new struct([
+  ['int16', 'x'],
+  ['int16', 'y'],
+]);
+
+var GSize = new struct([
+  ['int16', 'w'],
+  ['int16', 'h'],
+]);
+
+var GRect = new struct([
+  [GPoint, 'origin', PositionType],
+  [GSize, 'size', SizeType],
+]);
+
 var hexColorMap = {
   '#000000': 0xC0,
   '#000055': 0xC1,
@@ -504,6 +519,12 @@ var WindowHidePacket = new struct([
   ['uint32', 'id'],
 ]);
 
+var WindowLoadEventPacket = new struct([
+  [Packet, 'packet'],
+  ['uint32', 'id'],
+  [GSize, 'size']
+]);
+
 var WindowShowEventPacket = new struct([
   [Packet, 'packet'],
   ['uint32', 'id'],
@@ -807,6 +828,7 @@ var CommandPackets = [
   WakeupEventPacket,
   WindowShowPacket,
   WindowHidePacket,
+  WindowLoadEventPacket,
   WindowShowEventPacket,
   WindowHideEventPacket,
   WindowPropsPacket,
@@ -1432,6 +1454,9 @@ SimplyPebble.onPacket = function(buffer, offset) {
       ImageService.markAllUnloaded();
       WindowStack.emitHide(packet.id());
       break;
+    case WindowLoadEventPacket:
+      WindowStack.emitLoad(packet.id(), { w: packet.sizeW(), h: packet.sizeH() });
+      break;
     case ClickPacket:
       Window.emitClick('click', ButtonTypes[packet.button()]);
       break;
@@ -1485,4 +1510,3 @@ SimplyPebble.onAppMessage = function(e) {
 };
 
 module.exports = SimplyPebble;
-

--- a/src/js/ui/window.js
+++ b/src/js/ui/window.js
@@ -276,6 +276,10 @@ Window.prototype._emit = function(type, subtype, e) {
   }
 };
 
+Window.prototype._emitLoad = function(type, size) {
+  return this._emit(type, null, size);
+};
+
 Window.prototype._emitShow = function(type) {
   return this._emit(type, null, {});
 };

--- a/src/js/ui/windowstack.js
+++ b/src/js/ui/windowstack.js
@@ -19,6 +19,14 @@ WindowStack.prototype.top = function() {
   return util2.last(this._items);
 };
 
+WindowStack.prototype._emitLoad = function(item, size) {
+  item._emitLoad('load', size);
+  var e = {
+    window: item
+  };
+  this.emit('load', e);
+};
+
 WindowStack.prototype._emitShow = function(item) {
   item.forEachListener(item.onAddHandler);
   item._emitShow('show');
@@ -114,6 +122,11 @@ WindowStack.prototype.emitHide = function(windowId) {
   var wind = this.get(windowId);
   if (wind !== this.top()) { return; }
   this.remove(wind);
+};
+
+WindowStack.prototype.emitLoad = function(windowId, size) {
+  var wind = this.get(windowId);
+  this._emitLoad(wind, size);
 };
 
 WindowStack.prototype._toString = function() {

--- a/src/simply/simply_msg_commands.h
+++ b/src/simply/simply_msg_commands.h
@@ -12,6 +12,7 @@ enum Command {
   CommandWakeupEvent,
   CommandWindowShow,
   CommandWindowHide,
+  CommandWindowLoadEvent,
   CommandWindowShowEvent,
   CommandWindowHideEvent,
   CommandWindowProps,

--- a/src/simply/simply_window.c
+++ b/src/simply/simply_window.c
@@ -351,6 +351,10 @@ static void handle_window_props_packet(Simply *simply, Packet *data) {
   simply_window_set_background_color(window, packet->background_color);
   simply_window_set_fullscreen(window, packet->fullscreen);
   simply_window_set_scrollable(window, packet->scrollable);
+
+  Layer *window_layer = window_get_root_layer(window->window);
+  GRect frame = layer_get_frame(window_layer);
+  simply_window_stack_send_load(simply->window_stack, window, frame.size);
 }
 
 static void handle_window_button_config_packet(Simply *simply, Packet *data) {

--- a/src/simply/simply_window_stack.h
+++ b/src/simply/simply_window_stack.h
@@ -30,6 +30,7 @@ void simply_window_stack_show(SimplyWindowStack *self, SimplyWindow *window, boo
 void simply_window_stack_pop(SimplyWindowStack *self, SimplyWindow *window);
 void simply_window_stack_back(SimplyWindowStack *self, SimplyWindow *window);
 
+void simply_window_stack_send_load(SimplyWindowStack *self, SimplyWindow *window, GSize size);
 void simply_window_stack_send_show(SimplyWindowStack *self, SimplyWindow *window);
 void simply_window_stack_send_hide(SimplyWindowStack *self, SimplyWindow *window);
 


### PR DESCRIPTION
Add window load event for presenting the window client with dimensions.
This is useful for UI and general drawing.

I may be way off base with this patch and the direction you'd like to take the SDK. This information seems important for drawing in the JavaScript realm.