### PR TITLE
permit menu section title colors

### DIFF
--- a/src/js/ui/menu.js
+++ b/src/js/ui/menu.js
@@ -157,6 +157,10 @@ Menu.prototype._resolveMenu = function(clear, pushing) {
 Menu.prototype._resolveSection = function(e, clear) {
   var section = this._getSection(e);
   if (!section) { return; }
+  section = myutil.shadow({
+    textColor: this.state.textColor, 
+    backgroundColor: this.state.backgroundColor
+  }, section);
   section.items = this._getItems(e);
   if (this === WindowStack.top()) {
     simply.impl.menuSection.call(this, e.sectionIndex, section, clear);

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -641,6 +641,8 @@ var MenuSectionPacket = new struct([
   [Packet, 'packet'],
   ['uint16', 'section'],
   ['uint16', 'items', EnumerableType],
+  ['uint8', 'backgroundColor', Color],
+  ['uint8', 'textColor', Color],
   ['uint16', 'titleLength', EnumerableType],
   ['cstring', 'title', StringType],
 ]);
@@ -1213,6 +1215,8 @@ SimplyPebble.menuSection = function(section, def, clear) {
   MenuSectionPacket
     .section(section)
     .items(def.items)
+    .backgroundColor(def.backgroundColor)
+    .textColor(def.textColor)
     .titleLength(def.title)
     .title(def.title);
   SimplyPebble.sendPacket(MenuSectionPacket);

--- a/src/simply/simply_menu.c
+++ b/src/simply/simply_menu.c
@@ -46,6 +46,8 @@ struct __attribute__((__packed__)) MenuSectionPacket {
   Packet packet;
   uint16_t section;
   uint16_t num_items;
+  GColor8 background_color;
+  GColor8 text_color;  
   uint16_t title_length;
   char title[];
 };
@@ -340,10 +342,14 @@ static void menu_draw_header_callback(GContext *ctx, const Layer *cell_layer, ui
   list1_prepend(&self->menu_layer.sections, &section->node);
 
   GRect bounds = layer_get_bounds(cell_layer);
+
+  graphics_context_set_fill_color(ctx, gcolor8_get_or(section->title_background, GColorWhite));
+  graphics_fill_rect(ctx, bounds, 0, GCornerNone);
+
   bounds.origin.x += 2;
   bounds.origin.y -= 1;
 
-  graphics_context_set_text_color(ctx, gcolor8_get_or(self->menu_layer.normal_foreground, GColorBlack));
+  graphics_context_set_text_color(ctx, gcolor8_get_or(section->title_foreground, GColorBlack));
   graphics_draw_text(ctx, section->title, fonts_get_system_font(FONT_KEY_GOTHIC_14_BOLD),
                      bounds, GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
 }
@@ -551,6 +557,8 @@ static void handle_menu_section_packet(Simply *simply, Packet *data) {
   *section = (SimplyMenuSection) {
     .section = packet->section,
     .num_items = packet->num_items,
+    .title_foreground = packet->text_color,
+    .title_background = packet->background_color,
     .title = packet->title_length ? strdup2(packet->title) : NULL,
   };
   simply_menu_add_section(simply->menu, section);

--- a/src/simply/simply_menu.h
+++ b/src/simply/simply_menu.h
@@ -61,6 +61,8 @@ typedef struct SimplyMenuSection SimplyMenuSection;
 struct SimplyMenuSection {
   SimplyMenuCommonMember;
   uint16_t num_items;
+  GColor8 title_foreground;
+  GColor8 title_background;
 };
 
 typedef struct SimplyMenuItem SimplyMenuItem;


### PR DESCRIPTION
Menu sections can set different foreground/background colors for their titles
so that they are more easily distinguished from their items.  Falls back to
the foreground/background set for the whole menu if not specified.