### PR TITLE
Fix ReferenceError when using callback.

### DIFF
--- a/src/js/ui/menu.js
+++ b/src/js/ui/menu.js
@@ -308,7 +308,7 @@ Menu.prototype.item = function(sectionIndex, itemIndex, item) {
 
 Menu.prototype.selection = function(callback_or_sectionIndex, itemIndex) {
   if (typeof callback_or_sectionIndex === 'function') {
-    this._selections.push(callback);
+    this._selections.push(callback_or_sectionIndex);
     simply.impl.menuSelection();
   } else {
     this._selection = {


### PR DESCRIPTION
The follwing code 
```javascript
start.selection(function (e) {
  start._selected = e.item.station;
    destination.show();
});
```
will produce this error:
```
ReferenceError: callback is not defined
    at StationSelect.Menu.selection (ui/menu.js:311:27)
    at StationSelect.<anonymous> (app.js:52:17)
    at StationSelect.emitToHandlers (lib/emitter.js:121:17)
    at StationSelect.Emitter.emit (lib/emitter.js:145:31)
    at StationSelect.Window._emit (ui/window.js:274:12)
    at Function.Window.emit (ui/window.js:286:17)
    at Function.Menu.emitSelect (ui/menu.js:369:12)
    at Object.SimplyPebble.onPacket (ui/simply-pebble.js:1454:12)
    at Pebble.SimplyPebble.onAppMessage (ui/simply-pebble.js:1480:18)
```