### PR TITLE
Add the option to not send the current settings in the url hash

### DIFF
--- a/src/js/settings/settings.js
+++ b/src/js/settings/settings.js
@@ -165,7 +165,7 @@ Settings.onOpenConfig = function(e) {
     return;
   }
   var hash = encodeURIComponent(JSON.stringify(options));
-  Pebble.openURL(url + '#' + hash);
+  Pebble.openURL(url + (listener.params.noHash ? '' : '#' + hash));
 };
 
 Settings.onCloseConfig = function(e) {

--- a/src/js/settings/settings.js
+++ b/src/js/settings/settings.js
@@ -164,8 +164,9 @@ Settings.onOpenConfig = function(e) {
     options = Settings.getBaseOptions();
     return;
   }
-  var hash = encodeURIComponent(JSON.stringify(options));
-  Pebble.openURL(url + (listener.params.noHash ? '' : '#' + hash));
+  if (listener.params.hash !== false) 
+    url += '#' + encodeURIComponent(JSON.stringify(options));
+  Pebble.openURL(url);
 };
 
 Settings.onCloseConfig = function(e) {


### PR DESCRIPTION
When using data URLs, sending the options in the URL hash will break the URL