### PR TITLE
Add windowStack.length

### DIFF
--- a/src/js/ui/windowstack.js
+++ b/src/js/ui/windowstack.js
@@ -110,6 +110,10 @@ WindowStack.prototype.each = function(callback) {
   }
 };
 
+WindowStack.prototype.length = function() {
+  return this._items.length;
+};
+
 WindowStack.prototype.emitHide = function(windowId) {
   var wind = this.get(windowId);
   if (wind !== this.top()) { return; }


### PR DESCRIPTION
Allow applications to know the number of windows currently in the stack without having to loop through `windowStack.each`.

@Meiguro 