### PR TITLE
Feature chalk docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,30 @@ wind.show();
 
 Accessor to the `radius` property. See [Circle]
 
+### Radial
+
+An [Element] that can display as an arc, ring, sector of a circle depending on its properties are set.
+
+[Radial] has these additional properties:
+
+| Name              | Type      | Default   | Description                                                                                                                             |
+| ------------      | :-------: | --------- | -------------                                                                                                                           |
+| `radius`          | number    | 0         | Radius of the radial starting from its outer edge. A sufficiently large radius results in a sector or circle instead of an arc or ring. |
+| `angle`           | number    | 0         | Starting angle in degrees. An arc or sector will be drawn from `angle` to `angle2`.                                                     |
+| `angle2`          | number    | 360       | Ending angle in degrees. An ending angle that is 360 beyond the starting angle will result in a ring or circle.                         |
+
+#### Radial.radius(radius)
+
+Accessor to the `radius` property. See [Radial]
+
+#### Radial.angle(angle)
+
+Accessor to the `angle` starting angle property. See [Radial]
+
+#### Radial.angle2(angle)
+
+Accessor to the `angle2` ending angle property. See [Radial]
+
 ### Rect
 
 An [Element] that displays a rectangle on the screen.

--- a/README.md
+++ b/README.md
@@ -723,9 +723,9 @@ The properties available on a [Card] are:
 
 A [Card] is also a [Window] and thus also has Window properties.
 
-The small and large styles correspond to the system notification styles. Mono sets a monospace font for the body textfield, enabling more complex text UIs or ASCII art.
+The `'small'` and `'large`' styles correspond to the system notification styles. `'mono'` sets a monospace font for the body textfield, enabling more complex text UIs or ASCII art. The `'small'` and `'large'` styles were updated to match the Pebble firmware 3.x design during the 3.11 release. In order to use the older 2.x styles, you may specify `'classic-small'` and `'classic-large'`, however it is encouraged to use the newer styles.
 
-Note that all fields will automatically span multiple lines if needed and that you can '\n' to insert line breaks.
+Note that all text fields will automatically span multiple lines if needed and that you can use '\n' to insert line breaks.
 
 ### Menu
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Exporting is possible by modifying or setting `module.exports` within the requir
 
 ### Pebble
 
-The `Pebble` object from [PebbleKit JavaScript](https://developer.pebble.com/guides/pebble-apps/pebblekit-js/) is available as a global variable. Its usage is discouraged in Pebble.js, instead you should use the objects documented below who provide a cleaner object interface to the same functionalities.
+The `Pebble` object from [PebbleKit JavaScript](https://developer.pebble.com/guides/pebble-apps/pebblekit-js/) is available as a global variable. Its usage is discouraged in Pebble.js where there are equivalents. You should use the objects documented below that provide a cleaner object interface to the same functionalities. Use the `Pebble` object when there is no Pebble.js alternative.
 
 ### window -- browser
 

--- a/README.md
+++ b/README.md
@@ -445,13 +445,13 @@ document.location = 'pebblejs://close#' + encodeURIComponent(JSON.stringify(opti
 
 #### Settings.option(field, value)
 
-Saves `value` to `field`. It is recommended that `value` be either a primitive, or an object whose data is retained after going through `JSON.stringify` and `JSON.parse`.
+Saves `value` to `field`. It is recommended that `value` be either a primitive or an object whose data is retained after going through `JSON.stringify` and `JSON.parse`.
 
 ````js
 Settings.option('color', 'red');
 ````
 
-If value is undefined or null, the field will be deleted.
+If `value` is undefined or null, the field will be deleted.
 
 ````js
 Settings.option('color', null);
@@ -479,11 +479,16 @@ Settings.option({
 
 #### Settings.option()
 
-Returns all options. The options can be modified, but you must call `Settings.option` in a way that sets to save.
+Returns all options. The returned options can be modified, but if you want the modifications to be saved, you must call `Settings.option` as a setter.
 
 ````js
 var options = Settings.option();
 console.log(JSON.stringify(options));
+
+options.counter = (options.counter || 0) + 1;
+
+// Modifications are not saved until `Settings.option` is called as a setter
+Settings.option(options);
 ````
 
 #### Settings.data
@@ -494,13 +499,13 @@ While localStorage is still accessible, it is recommended to use `Settings.data`
 
 #### Settings.data(field, value)
 
-Saves `value` to `field`. It is recommended that `value` be either a primitive, or an object whose data is retained after going through `JSON.stringify` and `JSON.parse`.
+Saves `value` to `field`. It is recommended that `value` be either a primitive or an object whose data is retained after going through `JSON.stringify` and `JSON.parse`.
 
 ````js
 Settings.data('player', { id: 1, x: 10, y: 10 });
 ````
 
-If value is undefined or null, the field will be deleted.
+If `value` is undefined or null, the field will be deleted.
 
 ````js
 Settings.data('player', null);
@@ -528,11 +533,16 @@ Settings.data({
 
 #### Settings.data()
 
-Returns all data. The data can be modified, but you must call `Settings.data` in a way that sets to save.
+Returns all data. The returned data can be modified, but if you want the modifications to be saved, you must call `Settings.data` as a setter.
 
 ````js
 var data = Settings.data();
 console.log(JSON.stringify(data));
+
+data.counter = (data.counter || 0) + 1;
+
+// Modifications are not saved until `Settings.data` is called as a setter
+Settings.data(data);
 ````
 
 ## UI

--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ var Settings = require('settings');
 | ----       | :----:  | :--------: | --------- | -------------                                                                      |
 | `url`      | string  |            |           | The URL to the configurable. e.g. 'http://www.example.com?name=value'              |
 | `autoSave` | boolean | (optional) | true      | Whether to automatically save the web view response to options                     |
+| `hash`     | boolean | (optional) | true      | Whether to automatically concatenate the URI encoded json `Settings` options to the URL as the hash component. |
 
 `open` is an optional callback used to perform any tasks before the webview is open, such as managing the options that will be passed to the web view.
 

--- a/README.md
+++ b/README.md
@@ -867,6 +867,20 @@ card.status({
 });
 ````
 
+To disable the status bar after enabling it, `false` can be passed in place of `statusDef`.
+
+````js
+// Disable the status bar
+card.status(false);
+````
+
+Similarly, `true` can be used as a [Window statusDef] to represent a `statusDef` with all default properties.
+
+````js
+var card = new UI.Card({ status: true });
+card.show();
+````
+
 #### Window.status(field, value)
 
 `Window.status` can also be called with two arguments, `field` and `value`, to set specific fields of the window's `status` property. `field` is the name of a [Window statusDef] property as a string and `value` is the new property value.

--- a/README.md
+++ b/README.md
@@ -743,7 +743,18 @@ The properties available on a [Menu] are:
 | `highlightBackgroundColor`  | Color   | `black` | The background color of a selected menu item.     |
 | `highlightTextColor`        | Color   | `white` | The text color of a selected menu item.           |
 
-A menu contains one or more sections. Each section has a title and contains zero or more items. An item must have a title. It can also have a subtitle and an icon.
+A menu contains one or more sections.
+
+The properties available on a section are:
+
+| Name                        | Type    | Default | Description |
+| ----                        |:-------:|---------|-------------|
+| `items`                     | Array   | `[]`    | A list of all the items to display.               |
+| `title`                     | string  | ''      | Title text of the section header.                 |
+| `backgroundColor`           | Color   | `white` | The background color of the section header.       |
+| `textColor`                 | Color   | `black` | The text color of the section header.             |
+
+Each section has a title and contains zero or more items. An item must have a title. Items can also optionally have a subtitle and an icon.
 
 ````js
 var menu = new UI.Menu({

--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ Wakeup.schedule(
 )
 ````
 
+## Platform
+
+The Platform module allows you to determine the current platform runtime on the watch through its `Platform.version` method. This is to be used when the [Feature] module does not give enough ability to discern whether a feature exists or not.
+
+````js
+var Platform = require('platform');
+console.log('Current platform is ' + Platform.version());
+````
+
+### Platform.version()
+
+`Platform.version` returns the current platform version name as a lowercase string. This can be `'aplite'`, `'basalt'`, or `'chalk'`. Use the following table to determine the platform that `Platform.version` will return.
+
+| Watch Model          | Platform   |
+| ----                 | :----:     |
+| Pebble Classic       | `'aplite'` |
+| Pebble Steel Classic | `'aplite'` |
+| Pebble Time          | `'basalt'` |
+| Pebble Time Steel    | `'basalt'` |
+| Pebble Time Round    | `'chalk'`  |
+
 ## Settings
 
 The Settings module allows you to add a configurable web view to your application and share options with it. Settings also provides two data accessors `Settings.option` and `Settings.data` which are backed by localStorage. Data stored in `Settings.option` is automatically shared with the configurable web view.

--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ Pebble.js provides three types of Windows:
 
  * [Card]: Displays a title, a subtitle, a banner image and text on a screen. The position of the elements are fixed and cannot be changed.
  * [Menu]: Displays a menu on the Pebble screen. This is similar to the standard system menu in Pebble.
- * [Window]: The Window by itself is the most flexible. It allows you to add different [Element]s ([Circle], [Image], [Rect], [Text], [TimeText]) and to specify a position and size for each of them. You can also animate them.
+ * [Window]: The `Window` by itself is the most flexible. It allows you to add different [Element]s ([Circle], [Image], [Line], [Radial], [Rect], [Text], [TimeText]) and to specify a position and size for each of them. [Element]s can also be animated.
 
 A `Window` can have the following properties:
 
@@ -1091,7 +1091,7 @@ Similar to the select callback, except for long select presses. See [Menu.on('se
 ### Element
 [Element]: #element
 
-There are four types of [Element] that can be instantiated at the moment: [Circle], [Image], [Rect] and [Text].
+There are seven types of [Element] that can be instantiated at the moment: [Circle], [Image], [Line], [Radial], [Rect], [Text], [TimeText].
 
 Most elements share these common properties:
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can do much more with Pebble.js:
 Keep reading for the full [API Reference].
 
 ## Using Images
+[Using Images]: #using-images
 
 You can use images in your Pebble.js application. Currently all images must be embedded in your applications. They will be resized and converted to black and white when you build your project.
 
@@ -131,6 +132,7 @@ wind.show();
 ````
 
 ## Using Fonts
+[Using Fonts]: #using-fonts
 
 You can use any of the Pebble system fonts in your Pebble.js applications. Please refer to [this Pebble Developer's blog post](https://developer.pebble.com/blog/2013/07/24/Using-Pebble-System-Fonts/) for a list of all the Pebble system fonts. When referring to a font, using lowercase with dashes is recommended. For example, `GOTHIC_18_BOLD` becomes `gothic-18-bold`.
 
@@ -149,6 +151,7 @@ wind.show();
 ````
 
 # API Reference
+[API Reference]: #api-reference
 
 ## Global namespace
 
@@ -179,6 +182,7 @@ More specifically:
 If in doubt, please contact [devsupport@getpebble.com](mailto:devsupport@getpebble.com).
 
 ## Clock
+[Clock]: #clock
 
 The Clock module makes working with the Wakeup module with time utility functions.
 
@@ -219,6 +223,7 @@ Wakeup.schedule(
 ````
 
 ## Platform
+[Platform]: #platform
 
 The Platform module allows you to determine the current platform runtime on the watch through its `Platform.version` method. This is to be used when the [Feature] module does not give enough ability to discern whether a feature exists or not.
 
@@ -240,6 +245,7 @@ console.log('Current platform is ' + Platform.version());
 | Pebble Time Round    | `'chalk'`  |
 
 ### Feature
+[Feature]: #feature
 
 The Feature module under Platform allows you to perform feature detection, adjusting aspects of your app to the capabilities of the current watch model it is current running on. This allows you to consider the functionality of your app based on the current set of available capabilities or features. The Feature module also provides information about features that exist on all watch models such as `Feature.resolution` which returns the resolution of the current watch model.
 
@@ -350,6 +356,7 @@ var elementHeight = Feature.resolution().y - topMargin;
 ````
 
 ## Settings
+[Settings]: #settings
 
 The Settings module allows you to add a configurable web view to your application and share options with it. Settings also provides two data accessors `Settings.option` and `Settings.data` which are backed by localStorage. Data stored in `Settings.option` is automatically shared with the configurable web view.
 
@@ -514,10 +521,12 @@ console.log(JSON.stringify(data));
 ````
 
 ## UI
+[UI]: #ui
 
 The UI framework contains all the classes needed to build the user interface of your Pebble applications and interact with the user.
 
 ### Accel
+[Accel]: #accel
 
 The `Accel` module allows you to get events from the accelerometer on Pebble.
 
@@ -610,6 +619,7 @@ wind.on('accelData', function(e) {
 ````
 
 ### Voice
+[Voice]: #voice
 
 The `Voice` module allows you to interact with Pebble's dictation API on supported platforms (Basalt and Chalk).
 
@@ -649,6 +659,7 @@ Voice.dictate('stop');
 ```
 
 ### Window
+[Window]: #window
 
 `Window` is the basic building block in your Pebble.js application. All windows share some common properties and methods.
 
@@ -824,6 +835,7 @@ wind.each(function(element) {
 ````
 
 ### Card
+[Card]: #card
 
 A Card is a type of [Window] that allows you to display a title, a subtitle, an image and a body on the screen of Pebble.
 
@@ -859,6 +871,7 @@ The `'small'` and `'large`' styles correspond to the system notification styles.
 Note that all text fields will automatically span multiple lines if needed and that you can use '\n' to insert line breaks.
 
 ### Menu
+[Menu]: #menu
 
 A menu is a type of [Window] that displays a standard Pebble menu on the screen of Pebble.
 
@@ -994,6 +1007,7 @@ menu.on('select', function(e) {
 Similar to the select callback, except for long select presses. See [Menu.on('select', callback)].
 
 ### Element
+[Element]: #element
 
 There are four types of [Element] that can be instantiated at the moment: [Circle], [Image], [Rect] and [Text].
 
@@ -1105,6 +1119,7 @@ Accessor to the `borderColor` property. See [Element].
 Accessor to the `backgroundColor` property. See [Element].
 
 ### Line
+[Line]: #line
 
 An [Element] that displays a line on the screen.
 
@@ -1144,6 +1159,7 @@ Accessor to the `strokeWidth` property. See [Line].
 Accessor to the `strokeColor` property. See [Line].
 
 ### Circle
+[Circle]: #circle
 
 An [Element] that displays a circle on the screen.
 
@@ -1167,6 +1183,7 @@ wind.show();
 Accessor to the `radius` property. See [Circle]
 
 ### Radial
+[Radial]: #radial
 
 An [Element] that can display as an arc, ring, sector of a circle depending on its properties are set.
 
@@ -1191,6 +1208,7 @@ Accessor to the `angle` starting angle property. See [Radial]
 Accessor to the `angle2` ending angle property. See [Radial]
 
 ### Rect
+[Rect]: #rect
 
 An [Element] that displays a rectangle on the screen.
 
@@ -1202,6 +1220,7 @@ The [Rect] element has the following properties. Just like any other [Element] y
 | `borderColor`     | string    | "clear"   | Color of the border of this element ('clear', 'black',or 'white'). |
 
 ### Text
+[Text]: #text
 
 An [Element] that displays text on the screen.
 
@@ -1218,6 +1237,7 @@ The [Text] element has the following properties. Just like any other [Element] y
 | `backgroundColor` | string    | 'clear'   | Background color of this element ('clear', 'black' or 'white').                                                                                                                                                                                                                                                                                            |
 
 ### TimeText
+[TimeText]: #timetext
 
 A [Text] element that displays time formatted text on the screen.
 
@@ -1285,6 +1305,7 @@ Sets the borderColor property. See [Text].
 Sets the backgroundColor property. See [Text].
 
 ### Image
+[Image]: #image
 
 An [Element] that displays an image on the screen.
 
@@ -1316,6 +1337,7 @@ Sets the compositing operation to be used when rendering. Specify the compositin
 | `"set"`     | The image's black pixels are painted as white, and the rest are clear. |
 
 ### Vibe
+[Vibe]: #vibe
 
 `Vibe` allows you to trigger vibration on the user wrist.
 
@@ -1333,6 +1355,7 @@ Vibe.vibrate('long');
 | `type` | string | optional | `short` | The duration of the vibration. `short`, `long` or `double`. |
 
 ### Light
+[Light]: #light
 
 `Light` allows you to control the Pebble's backlight.
 ````js
@@ -1346,12 +1369,13 @@ Light.on('long');
 Turn on the light indefinitely.
 
 #### Light.auto()
-Restore the normal behaviour.
+Restore the normal behavior.
 
 #### Light.trigger()
 Trigger the backlight to turn on momentarily, just like if the user shook their wrist.
 
 ## Timeline
+[Timeline]: #timeline
 
 The Timeline module allows your app to handle a launch via a timeline action. This allows you to write a custom handler to manage launch events outside of the app menu. With the Timeline module, you can preform a specific set of actions based on the action which launched the app.
 
@@ -1390,6 +1414,7 @@ The `callback` will be called with a timeline launch event. The event has the fo
 Note that this means you may have to move portions of your startup logic into the `Timeline.launch` callback or a function called by the callback. This can also add a very small delay to startup behavior because the underlying implementation must query the watch for the launch information.
 
 ## Wakeup
+[Wakeup]: #wakeup
 
 The Wakeup module allows you to schedule your app to wakeup at a specified time using Pebble's wakeup functionality. Whether the user is in a different watchface or app, your app will launch at the specified time. This allows you to write a custom alarm app, for example. If your app is already running, you may also subscribe to receive the wakeup event, which can be useful for more longer lived timers. With the Wakeup module, you can save data to be read on launch and configure your app to behave differently based on launch data. The Wakeup module, like the Settings module, is backed by localStorage.
 
@@ -1581,6 +1606,7 @@ Cancels all wakeup events scheduled by your app. You can check what wakeup event
 Pebble.js includes several libraries to help you write applications.
 
 ### ajax
+[ajax]: #ajax
 
 This module gives you a very simple and easy way to make HTTP requests.
 
@@ -1620,6 +1646,7 @@ The `success` callback will be called if the HTTP request is successful (when th
 The `failure` callback is called when an error occurred. The parameters are the same as `success`.
 
 ### Vector2
+[Vector2]: #vector2
 
 A 2 dimensional vector. The constructor takes two parameters for the x and y values.
 
@@ -1630,22 +1657,6 @@ var vec = new Vector2(144, 168);
 ````
 
 For more information, see [Vector2 in the three.js reference documentation][three.js Vector2].
-
-
-[API Reference]: #api-reference
-[Using Images]: #using-images
-[Using Fonts]: #using-fonts
-
-[Clock]: #clock
-[Window]: #window
-[Card]: #card
-[Menu]: #menu
-[Element]: #element
-[Circle]: #circle
-[Image]: #image
-[Rect]: #rect
-[Text]: #text
-[TimeText]: #timetext
 [three.js Vector2]: http://threejs.org/docs/#Reference/Math/Vector2
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -676,6 +676,8 @@ Pebble.js provides three types of Windows:
  * [Menu]: Displays a menu on the Pebble screen. This is similar to the standard system menu in Pebble.
  * [Window]: The Window by itself is the most flexible. It allows you to add different [Element]s ([Circle], [Image], [Rect], [Text], [TimeText]) and to specify a position and size for each of them. You can also animate them.
 
+A `Window` can have the following properties:
+
 | Name           | Type      | Default   | Description                                                                                     |
 | ----           | :-------: | --------- | -------------                                                                                   |
 | `clear`        | boolean   |           |                                                                                                 |
@@ -687,25 +689,76 @@ Pebble.js provides three types of Windows:
 #### Window actionDef
 [Window actionDef]: #window-actiondef
 
-A `Window` action bar can be displayed by setting its Window `action` property to an `actionDef`:
+A `Window` action bar can be displayed by setting its Window `action` property to an `actionDef`.
+
+An `actionDef` has the following properties:
 
 | Name              | Type      | Default   | Description                                                                                            |
 | ----              | :-------: | --------- | -------------                                                                                          |
 | `up`              | Image     | None      | An image to display in the action bar, next to the up button.                                          |
 | `select`          | Image     | None      | An image to display in the action bar, next to the select button.                                      |
 | `down`            | Image     | None      | An image to display in the action bar, next to the down button.                                        |
-| `backgroundColor` | Color     | 'black'   | The background color of the action bar. You can set this to 'white' for windows with black backgrounds |
+| `backgroundColor` | Color     | 'black'   | The background color of the action bar. You can set this to 'white' for windows with black backgrounds. |
 
 ````js
+// Set action properties during initialization
 var card = new UI.Card({
   action: {
     up: 'images/action_icon_plus.png',
     down: 'images/action_icon_minus.png'
   }
 });
+
+// Set action properties after initialization
+card.action({
+  up: 'images/action_icon_plus.png',
+  down: 'images/action_icon_minus.png'
+});
+
+// Set a single action property
+card.action('select', 'images/action_icon_checkmark.png');
+
+// Disable the action bar
+card.action(false);
 ````
 
 You will need to add images to your project according to the [Using Images] guide in order to display action bar icons.
+
+<a id="window-statusdef"></a>
+#### Window statusDef
+[Window statusDef]: #window-statusdef
+
+A `Window` status bar can be displayed by setting its Window `status` property to a `statusDef`:
+
+A `statusDef` has the following properties:
+
+| Name              | Type      | Default   | Description                                                                                            |
+| ----              | :-------: | --------- | -------------                                                                                          |
+| `separator`       | string    | 'dotted'  | The separate between the status bar and the content of the window. Can be `'dotted'` or `'none'`.      |
+| `color`           | Color     | 'black'   | The foreground color of the status bar used to display the separator and time text.                    |
+| `backgroundColor` | Color     | 'white'   | The background color of the status bar. You can set this to 'black' for windows with white backgrounds. |
+
+````js
+// Set status properties during initialization
+var card = new UI.Card({
+  status: {
+    color: 'white',
+    backgroundColor: 'black'
+  }
+});
+
+// Set status properties after initialization
+card.status({
+  color: 'white',
+  backgroundColor: 'black'
+});
+
+// Set a single status property
+card.status('separator', 'none');
+
+// Disable the status bar
+card.status(false);
+````
 
 #### Window.show()
 
@@ -779,7 +832,7 @@ wind.on('hide', function() {
 
 #### Window.action(actionDef)
 
-This is a special nested accessor to the `action` property which takes an `actionDef`. It can be used to set a new `actionDef`. See [Window actionDef].
+Nested accessor to the `action` property which takes an `actionDef`. Used to configure the action bar with a new `actionDef`. See [Window actionDef].
 
 ````js
 card.action({
@@ -788,17 +841,39 @@ card.action({
 });
 ````
 
-#### Window.action(field, value)
-
-You may also call `Window.action` with two arguments, `field` and `value`, to set specific fields of the window's `action` propery. `field` is a string refering to the [actionDef] property to change. `value` is the new property value to set.
+To disable the action bar after enabling it, `false` can be passed in place of an `actionDef`.
 
 ````js
-card.action('up', 'images/action_icon_plus.png');
+// Disable the action bar
+card.action(false);
 ````
 
-#### Window.fullscreen(fullscreen)
+#### Window.action(field, value)
 
-Accessor to the `fullscreen` property. See [Window].
+`Window.action` can also be called with two arguments, `field` and `value`, to set specific fields of the window's `action` property. `field` is the name of a [Window actionDef] property as a string and `value` is the new property value.
+
+````js
+card.action('select', 'images/action_icon_checkmark.png');
+````
+
+#### Window.status(statusDef)
+
+Nested accessor to the `status` property which takes a `statusDef`. Used to configure the status bar with a new `statusDef`. See [Window statusDef].
+
+````js
+card.status({
+  color: 'white',
+  backgroundColor: 'black'
+});
+````
+
+#### Window.status(field, value)
+
+`Window.status` can also be called with two arguments, `field` and `value`, to set specific fields of the window's `status` property. `field` is the name of a [Window statusDef] property as a string and `value` is the new property value.
+
+````js
+card.status('separator', 'none');
+````
 
 ### Window (dynamic)
 
@@ -1151,7 +1226,7 @@ var line = new UI.Line({
 
 wind.add(line);
 wind.show();
-```
+````
 
 #### Line.position2(position)
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ In the examples above, mostly black text on white or light gray is used which ha
 Pebble.js provides the [Feature] module so that you may perform feature detection. This allows you change the presentation or behavior of your application based on the capabilities or characteristics of the current Pebble watch that the user is running your application with.
 
 ### Using Feature
-[Using Feature]: #feature-vs-platform
+[Using Feature]: #using-feature
 
 During the development of your Pebble.js application, you will want to test your application on all platforms. You can use the following local SDK command or change the current platform in CloudPebble.
 

--- a/README.md
+++ b/README.md
@@ -225,14 +225,17 @@ Wakeup.schedule(
 ## Platform
 [Platform]: #platform
 
-The Platform module allows you to determine the current platform runtime on the watch through its `Platform.version` method. This is to be used when the [Feature] module does not give enough ability to discern whether a feature exists or not.
+`Platform` provides a module of the same name `Platform` and a feature detection module [Feature].
 
 ````js
 var Platform = require('platform');
-console.log('Current platform is ' + Platform.version());
 ````
 
-### Platform.version()
+### Platform
+
+The Platform module allows you to determine the current platform runtime on the watch through its `Platform.version` method. This is to be used when the [Feature] module does not give enough ability to discern whether a feature exists or not.
+
+#### Platform.version()
 
 `Platform.version` returns the current platform version name as a lowercase string. This can be `'aplite'`, `'basalt'`, or `'chalk'`. Use the following table to determine the platform that `Platform.version` will return.
 
@@ -243,6 +246,10 @@ console.log('Current platform is ' + Platform.version());
 | Pebble Time          | `'basalt'` |
 | Pebble Time Steel    | `'basalt'` |
 | Pebble Time Round    | `'chalk'`  |
+
+````js
+console.log('Current platform is ' + Platform.version());
+````
 
 ### Feature
 [Feature]: #feature

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ A `Window` action bar can be displayed by setting its Window `action` property t
 | `up`              | Image     | None      | An image to display in the action bar, next to the up button.                                          |
 | `select`          | Image     | None      | An image to display in the action bar, next to the select button.                                      |
 | `down`            | Image     | None      | An image to display in the action bar, next to the down button.                                        |
-| `backgroundColor` | Image     | 'black'   | The background color of the action bar. You can set this to 'white' for windows with black backgrounds |
+| `backgroundColor` | Color     | 'black'   | The background color of the action bar. You can set this to 'white' for windows with black backgrounds |
 
 ````js
 var card = new UI.Card({
@@ -709,14 +709,19 @@ The properties available on a [Card] are:
 
 | Name         | Type      | Default   | Description                                                                                                                                                          |
 | ----         | :-------: | --------- | -------------                                                                                                                                                        |
-| `title`      | string    | ""        | Text to display in the title field at the top of the screen                                                                                                          |
-| `subtitle`   | string    | ""        | Text to display below the title                                                                                                                                      |
-| `body`       | string    | ""        | Text to display in the body field.                                                                                                                                   |
-| `icon`       | Image     | null      | An image to display before the title text. Refer to [Using Images] for instructions on how to include images in your app.                                                                     |
-| `subicon`    | Image     | null      | An image to display before the subtitle text. Refer to [Using Images] for instructions on how to include images in your app.                                                                     |
-| `banner`     | Image     | null      | An image to display in the center of the screen. Refer to [Using Images] for instructions on how to include images in your app.                                                                     |
+| `title`      | string    | ''        | Text to display in the title field at the top of the screen                                                                                                          |
+| `titleColor` | Color     | 'black'   | Text color of the title field                                                                                                                                             |
+| `subtitle`   | string    | ''        | Text to display below the title                                                                                                                                      |
+| `subtitleColor` | Color  | 'black'   | Text color of the subtitle field                                                                                                                                          |
+| `body`       | string    | ''        | Text to display in the body field                                                                                                                                    |
+| `bodyColor`  | Color     | 'black'   | Text color of the body field                                                                                                                                              |
+| `icon`       | Image     | null      | An image to display before the title text. Refer to [Using Images] for instructions on how to include images in your app.                                            |
+| `subicon`    | Image     | null      | An image to display before the subtitle text. Refer to [Using Images] for instructions on how to include images in your app.                                         |
+| `banner`     | Image     | null      | An image to display in the center of the screen. Refer to [Using Images] for instructions on how to include images in your app.                                      |
 | `scrollable` | boolean   | false     | Whether the user can scroll this card with the up and down button. When this is enabled, single and long click events on the up and down button will not be transmitted to your app. |
-| `style`      | string    | "small"   | Selects the font used to display the body. This can be 'small', 'large' or 'mono'                                                                                    |
+| `style`      | string    | 'small'   | Selects the font used to display the body. This can be 'small', 'large' or 'mono'                                                                                    |
+
+A [Card] is also a [Window] and thus also has Window properties.
 
 The small and large styles correspond to the system notification styles. Mono sets a monospace font for the body textfield, enabling more complex text UIs or ASCII art.
 

--- a/README.md
+++ b/README.md
@@ -388,8 +388,6 @@ Now, if it is necessary to separate the different logic in setting up the card, 
 
 The two examples consist of logic confined into one line, but if each line was instead large blocks of logic with the `isAplite` boolean used throughout, the issue is more apparent, hence the recommendation to use [Feature] detection. Of course, for capabilities or characteristics that [Feature] is unable to allow you to discern, use [Platform].
 
-**NOTE:** [Feature] underneath the hood does not actually perform feature detection. The benefit of using [Feature] however is that the detection logic is abstracted out of your application, so if any platform is changed or introduced, Pebble.js will update and your application will automatically adapt in the case that no new capabilities or characteristics are introduced.
-
 # API Reference
 [API Reference]: #api-reference
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,104 @@ menu.show();
 
 In the examples above, mostly black text on white or light gray is used which has the most contrast. Try to maintain this amount of contrast with text. Using dark gray on light gray for example can be unreadable at certain angles in the sunlight or in darkly lit areas.
 
+## Feature Detection
+[Feature Detection]: #feature-detection
+
+Pebble.js provides the [Feature] module so that you may perform feature detection. This allows you change the presentation or behavior of your application based on the capabilities or characteristics of the current Pebble watch that the user is running your application with.
+
+### Using Feature
+[Using Feature]: #feature-vs-platform
+
+During the development of your Pebble.js application, you will want to test your application on all platforms. You can use the following local SDK command or change the current platform in CloudPebble.
+
+> `pebble build && pebble install --emulator=aplite && pebble install --emulator=basalt && pebble install --emulator=chalk`
+
+You'll notice that there are a few differing capabilities across platforms, such as having `color` support or having a `round` screen. You can use [Feature.color()] and [Feature.round()] respectively in order to test for these capabilities. Most capability functions also have a direct opposite, such as [Feature.blackAndWhite()] and [Feature.rectangle()] respectively.
+
+The most common way to use [Feature] capability functions is to pass two parameters.
+
+````js
+var UI = require('ui');
+var Feature = require('platform/feature');
+
+// Use 'red' if round, otherwise use 'blue'
+var color = Feature.round('red', 'blue');
+
+var card = new UI.Card({
+  title: 'Color',
+  titleColor: color,
+});
+
+card.show();
+````
+
+You can also call the [Feature] capability functions with no arguments. In these cases, the function will return either `true` or `false` based on whether the capability exists.
+
+````js
+if (Feature.round()) {
+  // Perform round-only logic
+  console.log('This is a round device.');
+}
+````
+
+Among all Pebble platforms, there are characteristics that exist on all platforms, such as the device `resolution` and the height of the status bar. [Feature] also provides methods which gives additional information about these characteristics, such as [Feature.resolution()] and [Feature.statusBarHeight()].
+
+````js
+var res = Feature.resolution();
+console.log('Current display height is ' + res.y);
+````
+
+Check out the [Feature] API Reference for all the capabilities it detects and characteristics it offers.
+
+### Feature vs Platform
+[Feature vs Platform]: #feature-vs-platform
+
+When do you use [Feature] detection instead of just changing the logic based on the current [Platform]? Using feature detection allows you minimize the concerns of your logic, allowing it to be a single unit that does not rely on anything else unrelated.
+
+Consider the following [Platform] detection logic:
+
+````js
+var UI = require('ui');
+var Platform = require('platform');
+
+var isAplite = (Platform.version() === 'aplite');
+var isChalk = (Platform.version() === 'chalk');
+var card = new UI.Card({
+  title: 'Example',
+  titleColor: isAplite ? 'black' : 'dark-green',
+  subtitle: isChalk ? 'Hello World!' : 'Hello!',
+  body: isAplite ? 'Press up or down' : 'Speak to me',
+});
+
+card.show();
+````
+
+The first issue has to do with future proofing. It is checking if the current Pebble has a round screen by seeing if it is on Chalk, however there may be future platforms that have round screens. It can instead use [Feature.round()] which will update to include newer platforms as they are introduced.
+
+The second issue is unintentional entanglement of different concerns. `isAplite` is being used to both determine whether the Pebble is black and white and whether there is a microphone. It is harmless in this small example,  but when the code grows, it could potentially change such that a function both sets up the color and interaction based on a single boolean `isAplite`. This mixes color presentation logic with interaction logic.
+
+Consider the same example using [Feature] detection instead:
+
+````js
+var UI = require('ui');
+var Feature = require('platform/feature');
+
+var card = new UI.Card({
+  title: 'Example',
+  titleColor: Feature.color('dark-green', 'black'),
+  subtitle: Feature.round( 'Hello World!', 'Hello!'),
+  body: Feature.microphone('Speak to me', 'Press up or down'),
+});
+
+card.show();
+````
+
+Now, if it is necessary to separate the different logic in setting up the card, the individual units can be implemented in separate functions without anything unintentionally mixing the logic together. [Feature] is provided as a module, so it is always available where you decide to move your logic.
+
+The two examples consist of logic confined into one line, but if each line was instead large blocks of logic with the `isAplite` boolean used throughout, the issue is more apparent, hence the recommendation to use [Feature] detection. Of course, for capabilities or characteristics that [Feature] is unable to allow you to discern, use [Platform].
+
+**NOTE:** [Feature] underneath the hood does not actually perform feature detection. The benefit of using [Feature] however is that the detection logic is abstracted out of your application, so if any platform is changed or introduced, Pebble.js will update and your application will automatically adapt in the case that no new capabilities or characteristics are introduced.
+
 # API Reference
 [API Reference]: #api-reference
 
@@ -396,7 +494,7 @@ console.log('Current platform is ' + Platform.version());
 ### Feature
 [Feature]: #feature
 
-The Feature module under Platform allows you to perform feature detection, adjusting aspects of your app to the capabilities of the current watch model it is current running on. This allows you to consider the functionality of your app based on the current set of available capabilities or features. The Feature module also provides information about features that exist on all watch models such as `Feature.resolution` which returns the resolution of the current watch model.
+The Feature module under Platform allows you to perform feature detection, adjusting aspects of your application to the capabilities of the current watch model it is current running on. This allows you to consider the functionality of your application based on the current set of available capabilities or features. The Feature module also provides information about features that exist on all watch models such as `Feature.resolution` which returns the resolution of the current watch model.
 
 ````js
 var Feature = require('platform/feature');
@@ -405,10 +503,11 @@ console.log('Color is ' + Feature.color('avaiable', 'not available'));
 console.log('Display width is ' + Feature.resolution().x);
 ````
 
+<a id="feature-color"></a>
 #### Feature.color([yes, no])
 [Feature.color()]: #feature-color
 
-`Feature.color` will return the `yes` parameter if color is supported and `no` if it is not. This is the opposite of `Feature.blackAndWhite`. When given no parameters, it will return true or false respectively.
+`Feature.color` will return the `yes` parameter if color is supported and `no` if it is not. This is the opposite of [Feature.blackAndWhite()]. When given no parameters, it will return true or false respectively.
 
 ````js
 var textColor = Feature.color('oxford-blue', 'black');
@@ -419,9 +518,11 @@ if (Feature.color()) {
 }
 ````
 
+<a id="feature-blackAndWhite"></a>
 #### Feature.blackAndWhite([yes, no])
+[Feature.blackAndWhite()]: #feature-blackAndWhite
 
-`Feature.blackAndWhite` will return the `yes` parameter if only black and white is supported and `no` if it is not. This is the opposite of `Feature.color`. When given no parameters, it will return true or false respectively.
+`Feature.blackAndWhite` will return the `yes` parameter if only black and white is supported and `no` if it is not. This is the opposite of [Feature.color()]. When given no parameters, it will return true or false respectively.
 
 ````js
 var backgroundColor = Feature.blackAndWhite('white', 'clear');
@@ -432,9 +533,11 @@ if (Feature.blackAndWhite()) {
 }
 ````
 
+<a id="feature-rectangle"></a>
 #### Feature.rectangle([yes, no])
+[Feature.rectangle()]: #feature-rectangle
 
-`Feature.rectangle` will return the `yes` parameter if the watch screen is rectangular and `no` if it is not. This is the opposite of `Feature.round`. When given no parameters, it will return true or false respectively.
+`Feature.rectangle` will return the `yes` parameter if the watch screen is rectangular and `no` if it is not. This is the opposite of [Feature.round()]. When given no parameters, it will return true or false respectively.
 
 ````js
 var margin = Feature.rectangle(10, 20);
@@ -445,9 +548,11 @@ if (Feature.rectangle()) {
 }
 ````
 
+<a id="feature-round"></a>
 #### Feature.round([yes, no])
+[Feature.round()]: #feature-round
 
-`Feature.round` will return the `yes` parameter if the watch screen is round and `no` if it is not. This is the opposite of `Feature.rectangle`. When given no parameters, it will return true or false respectively.
+`Feature.round` will return the `yes` parameter if the watch screen is round and `no` if it is not. This is the opposite of [Feature.rectangle()]. When given no parameters, it will return true or false respectively.
 
 ````js
 var textAlign = Feature.round('center', 'left');
@@ -472,6 +577,7 @@ if (Feature.microphone()) {
 }
 ````
 
+<a id="feature-resolution"></a>
 #### Feature.resolution()
 [Feature.resolution()]: #feature-resolution
 
@@ -501,7 +607,9 @@ var elementWidth = Feature.resolution().x - rightMargin;
 
 **NOTE:** [Window.size()] already takes the action bar into consideration, so use it instead when possible.
 
+<a id="feature-statusBarHeight"></a>
 #### Feature.statusBarHeight()
+[Feature.statusBarHeight()]: #feature-statusBarHeight
 
 `Feature.statusBarHeight` returns the status bar height. This is `16` and can change accordingly if the Pebble Firmware theme ever changes. Useful for determining the remaining screen real estate in a dynamic [Window] with a status bar visible.
 
@@ -1050,6 +1158,7 @@ card.show();
 card.status('separator', 'none');
 ````
 
+<a id="window-size"></a>
 #### Window.size()
 [Window.size()]: #window-size
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,116 @@ console.log('Current platform is ' + Platform.version());
 | Pebble Time Steel    | `'basalt'` |
 | Pebble Time Round    | `'chalk'`  |
 
+### Feature
+
+The Feature module under Platform allows you to perform feature detection, adjusting aspects of your app to the capabilities of the current watch model it is current running on. This allows you to consider the functionality of your app based on the current set of available capabilities or features. The Feature module also provides information about features that exist on all watch models such as `Feature.resolution` which returns the resolution of the current watch model.
+
+````js
+var Feature = require('platform/feature');
+
+console.log('Color is ' + Feature.color('avaiable', 'not available'));
+console.log('Display width is ' + Feature.resolution().x);
+````
+
+#### Feature.color([yes, no])
+
+`Feature.color` will return the `yes` parameter if color is supported and `no` if it is not. This is the opposite of `Feature.blackAndWhite`. When given no parameters, it will return true or false respectively.
+
+````js
+var textColor = Feature.color('oxford-blue', 'black');
+
+if (Feature.color()) {
+  // Perform color-only operation
+  console.log('Color supported');
+}
+````
+
+#### Feature.blackAndWhite([yes, no])
+
+`Feature.blackAndWhite` will return the `yes` parameter if only black and white is supported and `no` if it is not. This is the opposite of `Feature.color`. When given no parameters, it will return true or false respectively.
+
+````js
+var backgroundColor = Feature.blackAndWhite('white', 'clear');
+
+if (Feature.blackAndWhite()) {
+  // Perform black-and-white-only operation
+  console.log('Black and white only');
+}
+````
+
+#### Feature.rectangle([yes, no])
+
+`Feature.rectangle` will return the `yes` parameter if the watch screen is rectangular and `no` if it is not. This is the opposite of `Feature.round`. When given no parameters, it will return true or false respectively.
+
+````js
+var margin = Feature.rectangle(10, 20);
+
+if (Feature.rectangle()) {
+  // Perform rectangular display only operation
+  console.log('Rectangular display');
+}
+````
+
+#### Feature.round([yes, no])
+
+`Feature.round` will return the `yes` parameter if the watch screen is round and `no` if it is not. This is the opposite of `Feature.rectangle`. When given no parameters, it will return true or false respectively.
+
+````js
+var textAlign = Feature.round('center', 'left');
+
+if (Feature.round()) {
+  // Perform round display only operation
+  console.log('Round display');
+}
+````
+
+#### Feature.microphone([yes, no])
+
+`Feature.microphone` will return the `yes` parameter if the watch has a microphone and `no` if it does not. When given no parameters, it will return true or false respectively. Useful for determining whether the `Voice` module will allow transcription or not and changing the UI accordingly.
+
+````js
+var text = Feature.microphone('Say your command.',
+                              'Select your command.');
+
+if (Feature.microphone()) {
+  // Perform microphone only operation
+  console.log('Microphone available');
+}
+````
+
+#### Feature.resolution()
+
+`Feature.resolution` returns a [Vector2] containing the display width as the `x` component and the display height as the `y` component. Use the following table to determine the resolution that `Feature.resolution` will return on a given platform.
+
+| Platform | Width | Height | Note                                                                                              |
+| ----     | :---: | :----: | ------                                                                                            |
+| aplite   | 144   | 168    |                                                                                                   |
+| basalt   | 144   | 168    | This is a rounded rectangle, therefore there is small set of pixels at each corner not available. |
+| chalk    | 180   | 180    | This is a circular display, therefore not all pixels in a 180 by 180 square are available.        |
+
+````js
+var res = Feature.resolution();
+console.log('Current display is ' + res.x + 'x' + res.y);
+````
+
+#### Feature.actionBarWidth()
+
+`Feature.actionBarWidth` returns the action bar width based on the platform. This is `30` for rectangular displays and `40` for round displays. Useful for determining the remaining screen real estate in a dynamic [Window] with an action bar visible.
+
+````js
+var rightMargin = Feature.actionBarWidth() + 5;
+var elementWidth = Feature.resolution().x - rightMargin;
+````
+
+#### Feature.statusBarHeight()
+
+`Feature.statusBarHeight` returns the status bar height. This is `16` and can change accordingly if the Pebble Firmware theme ever changes. Useful for determining the remaining screen real estate in a dynamic [Window] with a status bar visible.
+
+````js
+var topMargin = Feature.statusBarHeight() + 5;
+var elementHeight = Feature.resolution().y - topMargin;
+````
+
 ## Settings
 
 The Settings module allows you to add a configurable web view to your application and share options with it. Settings also provides two data accessors `Settings.option` and `Settings.data` which are backed by localStorage. Data stored in `Settings.option` is automatically shared with the configurable web view.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ In the examples above, mostly black text on white or light gray is used which ha
 ## Feature Detection
 [Feature Detection]: #feature-detection
 
-Pebble.js provides the [Feature] module so that you may perform feature detection. This allows you change the presentation or behavior of your application based on the capabilities or characteristics of the current Pebble watch that the user is running your application with.
+Pebble.js provides the [Feature] module so that you may perform feature detection. This allows you to change the presentation or behavior of your application based on the capabilities or characteristics of the current Pebble watch that the user is running your application with.
 
 ### Using Feature
 [Using Feature]: #using-feature
@@ -406,7 +406,54 @@ Exporting is possible by modifying or setting `module.exports` within the requir
 
 ### Pebble
 
-The `Pebble` object from [PebbleKit JavaScript](https://developer.pebble.com/guides/pebble-apps/pebblekit-js/) is available as a global variable. Its usage is discouraged in Pebble.js where there are equivalents. You should use the objects documented below that provide a cleaner object interface to the same functionalities. Use the `Pebble` object when there is no Pebble.js alternative.
+The `Pebble` object from [PebbleKit JavaScript](https://developer.pebble.com/guides/pebble-apps/pebblekit-js/) is available as a global variable. Some of the methods it provides have Pebble.js equivalents. When available, it is recommended to use the Pebble.js equivalents as they have more documented features and cleaner interfaces.
+
+This table lists the current Pebble.js equivalents:
+
+| Pebble API                                          | Pebble.js Equivalent                                     |
+| ------------                                        | :------:                                                 |
+| `Pebble.addEventListener('ready', ...)`             | Your application automatically starts after it is ready. |
+| `Pebble.addEventListener('showConfiguration', ...)` | [Settings.config()]                                      |
+| `Pebble.addEventListener('webviewclosed', ...)`     | [Settings.config()] with close handler.                  |
+
+Use `Pebble` when there is no Pebble.js alternative. Currently, these are the `Pebble` methods that have no direct Pebble.js alternative:
+
+| Pebble API without Equivalents    | Note                                                                   |
+| ------------                      | :---:                                                                  |
+| `Pebble.getAccountToken()`        |                                                                        |
+| `Pebble.getActiveWatchInfo()`     | Use [Platform.version()] if only querying for the platform version.    |
+| `Pebble.getTimelineToken()`       |                                                                        |
+| `Pebble.getWatchToken()`          |                                                                        |
+| `Pebble.showSimpleNotificationOnPebble()` | Consider presenting a [Card] or using Pebble Timeline instead. |
+| `Pebble.timelineSubscribe()`      |                                                                        |
+| `Pebble.timelineSubscriptions()`  |                                                                        |
+| `Pebble.timelineUnsubscribe()`    | &nbsp;                                                                 |
+
+### localStorage
+
+`localStorage` is [available for your use](https://developer.pebble.com/guides/communication/using-pebblekit-js/#using-localstorage), but consider using the [Settings] module instead which provides an alternative interface that can save and load JavaScript objects for you.
+
+````js
+var Settings = require('settings');
+
+Settings.data('playerInfo', { id: 1, name: 'Gordon Freeman' });
+var playerInfo = Settings.data('playerInfo');
+console.log("Player's name is " + playerInfo.name);
+````
+
+### XMLHttpRequest
+
+`XMLHttpRequest` is [available for your use](https://developer.pebble.com/guides/communication/using-pebblekit-js/#using-xmlhttprequest), but consider using the [ajax] module instead which provides a jQuery-like ajax alternative to performing asynchronous and synchronous HTTP requests, with built in support for forms and headers.
+
+````js
+var ajax = require('ajax');
+
+ajax({ url: 'http://api.theysaidso.com/qod.json', type: 'json' },
+  function(data, status, req) {
+    console.log('Quote of the day is: ' + data.contents.quote);
+  }
+);
+````
 
 ### window -- browser
 
@@ -474,7 +521,9 @@ The Platform module allows you to determine the current platform runtime on the 
 var Platform = require('platform');
 ````
 
+<a id="platform-version"></a>
 #### Platform.version()
+[Platform.version()]: #platform-version
 
 `Platform.version` returns the current platform version name as a lowercase string. This can be `'aplite'`, `'basalt'`, or `'chalk'`. Use the following table to determine the platform that `Platform.version` will return.
 
@@ -632,7 +681,9 @@ The Settings module allows you to add a configurable web view to your applicatio
 var Settings = require('settings');
 ````
 
+<a id="settings-config"></a>
 #### Settings.config(options, [open,] close)
+[Settings.config()]: #settings-config
 
 `Settings.config` registers your configurable for use along with `open` and `close` handlers.
 
@@ -1995,16 +2046,9 @@ This module gives you a very simple and easy way to make HTTP requests.
 ````js
 var ajax = require('ajax');
 
-ajax(
-  {
-    url: 'http://api.theysaidso.com/qod.json',
-    type: 'json'
-  },
-  function(data, status, request) {
+ajax({ url: 'http://api.theysaidso.com/qod.json', type: 'json' },
+  function(data) {
     console.log('Quote of the day is: ' + data.contents.quote);
-  },
-  function(error, status, request) {
-    console.log('The ajax request failed: ' + error);
   }
 );
 ````

--- a/README.md
+++ b/README.md
@@ -153,32 +153,32 @@ wind.show();
 ## Using Color
 [Using Color]: #using-color
 
-You can use Color in your Pebble.js applications by specifying them in the supported [Color Formats]. Use the [Pebble Color Picker](https://developer.pebble.com/guides/tools-and-resources/color-picker/) to find colors to use. Be sure to maintain [Readability and Contrast] when developing your application.
+You can use color in your Pebble.js applications by specifying them in the supported [Color Formats]. Use the [Pebble Color Picker](https://developer.pebble.com/guides/tools-and-resources/color-picker/) to find colors to use. Be sure to maintain [Readability and Contrast] when developing your application.
 
 ### Color Formats
 [Color Formats]: #color-formats
 
-Color can be specified in various ways in your Pebble.js application. The formats are named string, hexidecimal string, and hexidecimal number. Each format has different benefits.
+Color can be specified in various ways in your Pebble.js application. The formats are named string, hexadecimal string, and hexadecimal number. Each format has different benefits.
 
 The following table includes examples of all the supported formats in Pebble.js:
 
 | Color Format                    | Examples                   |
 | ------------                    | :------:                   |
 | Named String                    | `'green', 'sunset-orange'` |
-| Hexidecimal String              | `'#00ff00', '#ff5555'`     |
-| Hexidecimal String (with alpha) | `'#ff00ff00', '#ffff5555'` |
-| Hexidecimal Number              | `0x00ff00, 0xff5555`       |
-| Hexidecimal Number (with alpha) | `0xff00ff00, 0xffff5555`   |
+| Hexadecimal String              | `'#00ff00', '#ff5555'`     |
+| Hexadecimal String (with alpha) | `'#ff00ff00', '#ffff5555'` |
+| Hexadecimal Number              | `0x00ff00, 0xff5555`       |
+| Hexadecimal Number (with alpha) | `0xff00ff00, 0xffff5555`   |
 
-**Named strings** are convenient to remember and read more naturally. They however cannot have the alpha channel be specified with the exception of the named string color `'clear'`. All other named colors are at max opacity. Named colors can also be specified in other casing styles, such as C constant `'SUNSET_ORANGE'`, Pascal `'SunsetOrange'`, or camel case `'sunsetOrange'`. Use the casing most convenient for you, but do so consistently across your own codebase.
+**Named strings** are convenient to remember and read more naturally. They however cannot have the alpha channel be specified with the exception of the named string color `'clear'`. All other named colors are at max opacity. Named colors can also be specified in multiple casing styles, such as hyphenated lowercase `'sunset-orange'`, C constant `'SUNSET_ORANGE'`, Pascal `'SunsetOrange'`, or camel case `'sunsetOrange'`. Use the casing most convenient for you, but do so consistently across your own codebase.
 
-**Hexidecimal strings** can be used for specifying the exact color desired as Pebble.js will automatically round the color to the supported color of the current platform. Two hexidecimal digits are used to represent the three color channels red, green, blue in that order.
+**Hexadecimal strings** can be used for specifying the exact color desired as Pebble.js will automatically round the color to the supported color of the current platform. Two hexadecimal digits are used to represent the three color channels red, green, blue in that order.
 
-**Hexidecimal strings (with alpha)** specified with eight digits are parsed as having an alpha channel specified in the first two digits where `00` is clear and `ff` is full opacity.
+**Hexadecimal strings (with alpha)** specified with eight digits are parsed as having an alpha channel specified in the first two digits where `00` is clear and `ff` is full opacity.
 
-**Hexidecimal numbers** can be manipulated directly with the arithmetic and bitwise operators. This is also the format which the configurable framework Clay uses.
+**Hexadecimal numbers** can be manipulated directly with the arithmetic and bitwise operators. This is also the format which the configurable framework Clay uses.
 
-**Hexidecimal numbers (with alpha)** also have an alpha channel specified, but it is recommended to use hexidecimal strings instead for two reasons. The first reason is that `00` also represents full opacity since they are equivalent to six digit hexidecimal numbers which are implicitly at full opacity. The second is that when explicitly representing full opacity as `ff`, some integer logic can cause a signed overflow, resulting in negative color values. Intermediate alpha channels such as `55` or `aa` have no such caveats.
+**Hexadecimal numbers (with alpha)** also have an alpha channel specified, but it is recommended to use hexadecimal strings instead for two reasons. The first reason is that `00` also represents full opacity since they are equivalent to six digit hexadecimal numbers which are implicitly at full opacity. The second is that when explicitly representing full opacity as `ff`, some integer logic can cause a signed overflow, resulting in negative color values. Intermediate alpha channels such as `55` or `aa` have no such caveats.
 
 Various parts of the Pebble.js API support color. Parameters of the type Color can take any of the color formats mentioned in the above table.
 
@@ -189,9 +189,9 @@ var card = new UI.Card({
   title: 'Using Color',
   titleColor: 'sunset-orange', // Named string
   subtitle: 'Color',
-  subtitleColor: '#00dd00', // 6-digit Hexidecimal string
+  subtitleColor: '#00dd00', // 6-digit Hexadecimal string
   body: 'Format',
-  bodyColor: 0x9a0036 // 6-digit Hexidecimal number
+  bodyColor: 0x9a0036 // 6-digit Hexadecimal number
 });
 
 card.show();
@@ -229,7 +229,7 @@ Using too much color such as in the previous example can be overwhelming however
 var card = new UI.Card({
   status: {
     color: 'white',
-    backgroundColor: Feature.color('eletric-ultramarine', 'black'),
+    backgroundColor: Feature.color('electric-ultramarine', 'black'),
     separator: 'none',
   },
   title: 'Using Color',

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ During the development of your Pebble.js application, you will want to test your
 
 > `pebble build && pebble install --emulator=aplite && pebble install --emulator=basalt && pebble install --emulator=chalk`
 
-You'll notice that there are a few differing capabilities across platforms, such as having `color` support or having a `round` screen. You can use [Feature.color()] and [Feature.round()] respectively in order to test for these capabilities. Most capability functions also have a direct opposite, such as [Feature.blackAndWhite()] and [Feature.rectangle()] respectively.
+You'll notice that there are a few differing capabilities across platforms, such as having color support or having a round screen. You can use [Feature.color()] and [Feature.round()] respectively in order to test for these capabilities. Most capability functions also have a direct opposite, such as [Feature.blackAndWhite()] and [Feature.rectangle()] respectively.
 
 The most common way to use [Feature] capability functions is to pass two parameters.
 
@@ -332,7 +332,7 @@ if (Feature.round()) {
 }
 ````
 
-Among all Pebble platforms, there are characteristics that exist on all platforms, such as the device `resolution` and the height of the status bar. [Feature] also provides methods which gives additional information about these characteristics, such as [Feature.resolution()] and [Feature.statusBarHeight()].
+Among all Pebble platforms, there are characteristics that exist on all platforms, such as the device resolution and the height of the status bar. [Feature] also provides methods which gives additional information about these characteristics, such as [Feature.resolution()] and [Feature.statusBarHeight()].
 
 ````js
 var res = Feature.resolution();
@@ -344,7 +344,7 @@ Check out the [Feature] API Reference for all the capabilities it detects and ch
 ### Feature vs Platform
 [Feature vs Platform]: #feature-vs-platform
 
-When do you use [Feature] detection instead of just changing the logic based on the current [Platform]? Using feature detection allows you minimize the concerns of your logic, allowing it to be a single unit that does not rely on anything else unrelated.
+Pebble.js offers both [Feature] detection and [Platform] detection which are different. When do you use [Feature] detection instead of just changing the logic based on the current [Platform]? Using feature detection allows you to minimize the concerns of your logic, allowing each section of logic to be a single unit that does not rely on anything else unrelated.
 
 Consider the following [Platform] detection logic:
 
@@ -366,7 +366,7 @@ card.show();
 
 The first issue has to do with future proofing. It is checking if the current Pebble has a round screen by seeing if it is on Chalk, however there may be future platforms that have round screens. It can instead use [Feature.round()] which will update to include newer platforms as they are introduced.
 
-The second issue is unintentional entanglement of different concerns. `isAplite` is being used to both determine whether the Pebble is black and white and whether there is a microphone. It is harmless in this small example,  but when the code grows, it could potentially change such that a function both sets up the color and interaction based on a single boolean `isAplite`. This mixes color presentation logic with interaction logic.
+The second issue is unintentional entanglement of different concerns. In the example above, `isAplite` is being used to both determine whether the Pebble is black and white and whether there is a microphone. It is harmless in this small example,  but when the code grows, it could potentially change such that a function both sets up the color and interaction based on a single boolean `isAplite`. This mixes color presentation logic with interaction logic.
 
 Consider the same example using [Feature] detection instead:
 
@@ -386,7 +386,7 @@ card.show();
 
 Now, if it is necessary to separate the different logic in setting up the card, the individual units can be implemented in separate functions without anything unintentionally mixing the logic together. [Feature] is provided as a module, so it is always available where you decide to move your logic.
 
-The two examples consist of logic confined into one line, but if each line was instead large blocks of logic with the `isAplite` boolean used throughout, the issue is more apparent, hence the recommendation to use [Feature] detection. Of course, for capabilities or characteristics that [Feature] is unable to allow you to discern, use [Platform].
+The two examples consist of units of logic that consist of one liners, but if each line was instead large blocks of logic with the `isAplite` boolean used throughout, the entanglement issue would be more difficult to remove from your codebase, hence the recommendation to use [Feature] detection. Of course, for capabilities or characteristics that [Feature] is unable to allow you to discern, use [Platform].
 
 # API Reference
 [API Reference]: #api-reference

--- a/README.md
+++ b/README.md
@@ -871,15 +871,19 @@ They all share some common properties:
 | Name              | Type      | Default   | Description                                                                    |
 | ------------      | :-------: | --------- | -------------                                                                  |
 | `position`        | Vector2   |           | Position of this element in the window.                                        |
-| `size`            | Vector2   |           | Size of this element in this window. Note that [Circle] uses `radius` instead. |
-| `borderColor`     | string    | ''        | Color of the border of this element ('clear', 'black',or 'white').             |
-| `backgroundColor` | string    | ''        | Background color of this element ('clear', 'black' or 'white').                |
+| `size`            | Vector2   |           | Size of this element in this window. [Circle] uses `radius` instead.           |
+| `borderWidth`     | number    | 0         | Width of the border of this element.                                           |
+| `borderColor`     | Color     | 'clear'   | Color of the border of this element.                                           |
+| `backgroundColor` | Color     | 'white'   | Background color of this element.                                              |
 
-All properties can be initialized by passing an object when creating the Element, and changed with accessors functions who have the name of the properties. Calling an accessor without a parameter will return the current value.
+All properties can be initialized by passing an object when creating the Element, and changed with accessors functions that have the same name as the properties. Calling an accessor without a parameter will return the current value.
 
 ````js
 var Vector2 = require('vector2');
-var element = new Text({ position: new Vector2(0, 0), size: new Vector2(144, 168) });
+var element = new Text({
+  position: new Vector2(0, 0),
+  size: new Vector2(144, 168),
+});
 element.borderColor('white');
 console.log('This element background color is: ' + element.backgroundColor());
 ````
@@ -956,6 +960,10 @@ Accessor to the `position` property. See [Element].
 #### Element.size(size)
 
 Accessor to the `size` property. See [Element].
+
+#### Element.borderWidth(width)
+
+Accessor to the `borderWidth` property. See [Element].
 
 #### Element.borderColor(color)
 

--- a/README.md
+++ b/README.md
@@ -866,15 +866,15 @@ Similar to the select callback, except for long select presses. See [Menu.on('se
 
 There are four types of [Element] that can be instantiated at the moment: [Circle], [Image], [Rect] and [Text].
 
-They all share some common properties:
+Most elements share these common properties:
 
 | Name              | Type      | Default   | Description                                                                    |
 | ------------      | :-------: | --------- | -------------                                                                  |
 | `position`        | Vector2   |           | Position of this element in the window.                                        |
 | `size`            | Vector2   |           | Size of this element in this window. [Circle] uses `radius` instead.           |
-| `borderWidth`     | number    | 0         | Width of the border of this element.                                           |
-| `borderColor`     | Color     | 'clear'   | Color of the border of this element.                                           |
-| `backgroundColor` | Color     | 'white'   | Background color of this element.                                              |
+| `borderWidth`     | number    | 0         | Width of the border of this element. [Line] uses `strokeWidth` instead.        |
+| `borderColor`     | Color     | 'clear'   | Color of the border of this element. [Line] uses `strokeColor` instead.        |
+| `backgroundColor` | Color     | 'white'   | Background color of this element. [Line] has no background.                    |
 
 All properties can be initialized by passing an object when creating the Element, and changed with accessors functions that have the same name as the properties. Calling an accessor without a parameter will return the current value.
 
@@ -973,14 +973,48 @@ Accessor to the `borderColor` property. See [Element].
 
 Accessor to the `backgroundColor` property. See [Element].
 
+### Line
+
+An [Element] that displays a line on the screen.
+
+[Line] also has these additional properties:
+
+| Name              | Type      | Default   | Description                                                                    |
+| ------------      | :-------: | --------- | -------------                                                                  |
+| `position2`       | Vector2   |           | Ending position of the line where `position` is the starting position.         |
+| `strokeWidth`     | number    | 0         | Width of the line.                                                             |
+| `strokeColor`     | Color     | 'clear'   | Color of the line.                                                             |
+
+For clarity, [Line] has `strokeWidth` and `strokeColor` instead of `borderWidth` and `borderColor`.
+
+````js
+var wind = new UI.Window();
+
+var line = new UI.Line({
+  position: new Vector2(10, 10),
+  position2: new Vector2(72, 84),
+  strokeColor: 'white',
+});
+
+wind.add(line);
+wind.show();
+```
+
+#### Line.position2(position)
+
+Accessor to the `position2` ending position property. See [Line].
+
+#### Line.strokeWidth(width)
+
+Accessor to the `strokeWidth` property. See [Line].
+
+#### Line.strokeColor(color)
+
+Accessor to the `strokeColor` property. See [Line].
+
 ### Circle
 
 An [Element] that displays a circle on the screen.
-
-Default properties value:
-
- * `backgroundColor`: 'white'
- * `borderColor`: 'clear'
 
 [Circle] also has the additional property `radius` which it uses for size rather than `size`. [Circle] is also different in that it positions its origin at the position, rather than anchoring by its top left. These differences are to keep the graphics operation characteristics that it is built upon.
 
@@ -994,7 +1028,7 @@ var circle = new UI.Circle({
 });
 
 wind.add(circle);
-wind.show(circle);
+wind.show();
 ````
 
 #### Circle.radius(radius)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,148 @@ wind.add(textfield);
 wind.show();
 ````
 
+## Using Color
+[Using Color]: #using-color
+
+You can use Color in your Pebble.js applications by specifying them in the supported [Color Formats]. Use the [Pebble Color Picker](https://developer.pebble.com/guides/tools-and-resources/color-picker/) to find colors to use. Be sure to maintain [Readability and Contrast] when developing your application.
+
+### Color Formats
+[Color Formats]: #color-formats
+
+Color can be specified in various ways in your Pebble.js application. The formats are named string, hexidecimal string, and hexidecimal number. Each format has different benefits.
+
+The following table includes examples of all the supported formats in Pebble.js:
+
+| Color Format                    | Examples                   |
+| ------------                    | :------:                   |
+| Named String                    | `'green', 'sunset-orange'` |
+| Hexidecimal String              | `'#00ff00', '#ff5555'`     |
+| Hexidecimal String (with alpha) | `'#ff00ff00', '#ffff5555'` |
+| Hexidecimal Number              | `0x00ff00, 0xff5555`       |
+| Hexidecimal Number (with alpha) | `0xff00ff00, 0xffff5555`   |
+
+**Named strings** are convenient to remember and read more naturally. They however cannot have the alpha channel be specified with the exception of the named string color `'clear'`. All other named colors are at max opacity. Named colors can also be specified in other casing styles, such as C constant `'SUNSET_ORANGE'`, Pascal `'SunsetOrange'`, or camel case `'sunsetOrange'`. Use the casing most convenient for you, but do so consistently across your own codebase.
+
+**Hexidecimal strings** can be used for specifying the exact color desired as Pebble.js will automatically round the color to the supported color of the current platform. Two hexidecimal digits are used to represent the three color channels red, green, blue in that order.
+
+**Hexidecimal strings (with alpha)** specified with eight digits are parsed as having an alpha channel specified in the first two digits where `00` is clear and `ff` is full opacity.
+
+**Hexidecimal numbers** can be manipulated directly with the arithmetic and bitwise operators. This is also the format which the configurable framework Clay uses.
+
+**Hexidecimal numbers (with alpha)** also have an alpha channel specified, but it is recommended to use hexidecimal strings instead for two reasons. The first reason is that `00` also represents full opacity since they are equivalent to six digit hexidecimal numbers which are implicitly at full opacity. The second is that when explicitly representing full opacity as `ff`, some integer logic can cause a signed overflow, resulting in negative color values. Intermediate alpha channels such as `55` or `aa` have no such caveats.
+
+Various parts of the Pebble.js API support color. Parameters of the type Color can take any of the color formats mentioned in the above table.
+
+````js
+var UI = require('ui');
+
+var card = new UI.Card({
+  title: 'Using Color',
+  titleColor: 'sunset-orange', // Named string
+  subtitle: 'Color',
+  subtitleColor: '#00dd00', // 6-digit Hexidecimal string
+  body: 'Format',
+  bodyColor: 0x9a0036 // 6-digit Hexidecimal number
+});
+
+card.show();
+````
+
+### Readability and Contrast
+[Readability and Contrast]: #readability-and-contrast
+
+When using color or not, be mindful that your users may not have a Pebble supporting color or the reverse. Black and white Pebbles will display colors with medium luminance as a gray checkered pattern which makes text of any color difficult to read. In Pebble.js, you can use [Feature.color()] to use a different value depending on whether color is supported.
+
+````js
+var UI = require('ui');
+var Feature = require('platform/feature');
+
+var card = new UI.Card({
+  title: 'Using Color',
+  titleColor: Feature.color('sunset-orange', 'black'),
+  subtitle: 'Readability',
+  subtitleColor: Feature.color('#00dd00', 'black'),
+  body: 'Contrast',
+  bodyColor: Feature.color(0x9a0036, 'black'),
+  backgroundColor: Feature.color('light-gray', 'white'),
+});
+
+card.show();
+````
+
+Whether you have a color Pebble or not, you will want to test your app in all platforms. You can see how your app looks in multiple platforms with the following local SDK command or by changing the current platform in CloudPebble.
+
+> `pebble build && pebble install --emulator=aplite && pebble install --emulator=basalt && pebble install --emulator=chalk`
+
+Using too much color such as in the previous example can be overwhelming however. Just using one color that stands out in a single place can have a more defined effect and remain readable.
+
+````js
+var card = new UI.Card({
+  status: {
+    color: 'white',
+    backgroundColor: Feature.color('eletric-ultramarine', 'black'),
+    separator: 'none',
+  },
+  title: 'Using Color',
+  subtitle: 'Readability',
+  body: 'Contrast',
+});
+````
+
+Likewise, if introducing an action bar, you can remove all color from the status bar and instead apply color to the action bar.
+
+````js
+var card = new UI.Card({
+  status: true,
+  action: {
+    backgroundColor: Feature.color('jazzberry-jam', 'black'),
+  },
+  title: 'Dialog',
+  subtitle: 'Action',
+  body: 'Button',
+});
+````
+
+When changing the background color, note that the status bar also needs its background color changed too if you would like it to match.
+
+````js
+var backgroundColor = Feature.color('light-gray', 'black');
+var card = new UI.Card({
+  status: {
+    backgroundColor: backgroundColor,
+    separator: Feature.round('none', 'dotted'),
+  },
+  action: {
+    backgroundColor: 'black',
+  },
+  title: 'Music',
+  titleColor: Feature.color('orange', 'black'),
+  subtitle: 'Playing',
+  body: 'Current Track',
+  backgroundColor: backgroundColor,
+});
+````
+
+For a menu, following this style of coloring, you would only set the `highlightBackgroundColor`.
+
+````js
+var menu = new UI.Menu({
+  status: {
+    separator: Feature.round('none', 'dotted'),
+  },
+  highlightBackgroundColor: Feature.color('vivid-violet', 'black'),
+  sections: [{
+    items: [{ title: 'One', subtitle: 'Using Color' },
+            { title: 'Color', subtitle: 'Color Formats' },
+            { title: 'Hightlight', subtitle: 'Readability' }],
+  }],
+});
+
+menu.show();
+````
+
+In the examples above, mostly black text on white or light gray is used which has the most contrast. Try to maintain this amount of contrast with text. Using dark gray on light gray for example can be unreadable at certain angles in the sunlight or in darkly lit areas.
+
 # API Reference
 [API Reference]: #api-reference
 
@@ -264,6 +406,7 @@ console.log('Display width is ' + Feature.resolution().x);
 ````
 
 #### Feature.color([yes, no])
+[Feature.color()]: #feature-color
 
 `Feature.color` will return the `yes` parameter if color is supported and `no` if it is not. This is the opposite of `Feature.blackAndWhite`. When given no parameters, it will return true or false respectively.
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ If in doubt, please contact [devsupport@getpebble.com](mailto:devsupport@getpebb
 ## Clock
 [Clock]: #clock
 
-The Clock module makes working with the Wakeup module with time utility functions.
+The Clock module makes working with the [Wakeup] module simpler with its provided time utility functions.
 
 ### Clock
 

--- a/README.md
+++ b/README.md
@@ -467,13 +467,14 @@ Wakeup.schedule(
 
 `Platform` provides a module of the same name `Platform` and a feature detection module [Feature].
 
-````js
-var Platform = require('platform');
-````
 
 ### Platform
 
 The Platform module allows you to determine the current platform runtime on the watch through its `Platform.version` method. This is to be used when the [Feature] module does not give enough ability to discern whether a feature exists or not.
+
+````js
+var Platform = require('platform');
+````
 
 #### Platform.version()
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ if (Feature.microphone()) {
 ````
 
 #### Feature.resolution()
+[Feature.resolution()]: #feature-resolution
 
 `Feature.resolution` returns a [Vector2] containing the display width as the `x` component and the display height as the `y` component. Use the following table to determine the resolution that `Feature.resolution` will return on a given platform.
 
@@ -338,6 +339,8 @@ if (Feature.microphone()) {
 | aplite   | 144   | 168    |                                                                                                   |
 | basalt   | 144   | 168    | This is a rounded rectangle, therefore there is small set of pixels at each corner not available. |
 | chalk    | 180   | 180    | This is a circular display, therefore not all pixels in a 180 by 180 square are available.        |
+
+**NOTE:** [Window]s also have a [Window.size()] method which returns its size as a [Vector2]. Use [Window.size()] when possible.
 
 ````js
 var res = Feature.resolution();
@@ -353,6 +356,8 @@ var rightMargin = Feature.actionBarWidth() + 5;
 var elementWidth = Feature.resolution().x - rightMargin;
 ````
 
+**NOTE:** [Window.size()] already takes the action bar into consideration, so use it instead when possible.
+
 #### Feature.statusBarHeight()
 
 `Feature.statusBarHeight` returns the status bar height. This is `16` and can change accordingly if the Pebble Firmware theme ever changes. Useful for determining the remaining screen real estate in a dynamic [Window] with a status bar visible.
@@ -361,6 +366,8 @@ var elementWidth = Feature.resolution().x - rightMargin;
 var topMargin = Feature.statusBarHeight() + 5;
 var elementHeight = Feature.resolution().y - topMargin;
 ````
+
+**NOTE:** [Window.size()] already takes the status bar into consideration, so use it instead when possible.
 
 ## Settings
 [Settings]: #settings
@@ -887,6 +894,23 @@ card.show();
 
 ````js
 card.status('separator', 'none');
+````
+
+#### Window.size()
+[Window.size()]: #window-size
+
+`Window.size` returns the size of the max viewable content size of the window as a [Vector2] taking into account whether there is an action bar and status bar. A [Window] will return a size that is shorter than a [Window] without for example.
+
+If the automatic consideration of the action bar and status bar does not satisfy your use case, you can use [Feature.resolution()] to obtain the Pebble's screen resolution as a [Vector2].
+
+````js
+var wind = new UI.Window({ status: true });
+
+var size = wind.size();
+var rect = new UI.Rect({ size: new Vector2(size.x / 4, size.y / 4) });
+wind.add(rect);
+
+wind.show();
 ````
 
 ### Window (dynamic)


### PR DESCRIPTION
The long awaited documentation for all the new features. All the newly introduced color fields are documented, new elements Line and Radial, and new modules Platform and Feature. Two guides are added in order to give a clearer direction for developing on Pebble.js in light of supporting Chalk.

Once everything looks good, a CloudPebble update will be requested, and this will be merged. This will address #96, #116, #156 .