### PR TITLE
Move initial dequeuing from animate to queue function.

### DIFF
--- a/src/js/ui/element.js
+++ b/src/js/ui/element.js
@@ -93,14 +93,15 @@ StageElement.prototype.animate = function(field, value, duration) {
     this._animate(animateDef, duration);
     util2.copy(animateDef, this.state);
   });
-  if (!this.state.animating) {
-    this.dequeue();
-  }
   return this;
 };
 
 StageElement.prototype.queue = function(callback) {
   this._queue.push(callback);
+  if (!this.state.animating) {
+    this.dequeue();
+  }
+  return this;
 };
 
 StageElement.prototype.dequeue = function() {


### PR DESCRIPTION
When queuing custom operations with no ongoing animation or when the element is idle, nothing happens. This change ensures that you can initialize the queue with a custom callback and it starts dequeuing the animation queue properly.

This comes handy for example when you want to hide or show a window after an animation is finished or when the element is not doing any animations.