### PR TITLE
Minor bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pebblejs",
   "author": "Meiguro",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": "pebble/pebblejs",
   "license": "MIT",
   "files": ["dist.zip"],

--- a/src/c/util/graphics.h
+++ b/src/c/util/graphics.h
@@ -5,7 +5,7 @@
 
 #include <pebble.h>
 
-#ifndef PBL_SDK_3
+#ifdef PBL_SDK_2
 
 #define GCompOpAlphaBlend GCompOpAnd
 

--- a/src/js/platform/platform.js
+++ b/src/js/platform/platform.js
@@ -1,7 +1,7 @@
 var Platform = module.exports;
 
 Platform.version = function() {
-  if (Pebble.getActiveWatchInfo) {
+  if (Pebble.getActiveWatchInfo()) {
     return Pebble.getActiveWatchInfo().platform;
   } else {
     return 'aplite';


### PR DESCRIPTION
- Use `GCompOpSet` for any SDK > 2 (although this code path doesn't seem to be in use because of JS overrides)
- Check `getActiveWatchInfo()` instead of `getActiveWatchInfo`