### PR TITLE
Fix accelerometer sample's time property

### DIFF
--- a/src/js/lib/struct.js
+++ b/src/js/lib/struct.js
@@ -58,7 +58,7 @@ struct.types.uint64.get = function(offset, little) {
   var a = buffer.getUint32(offset, little);
   var b = buffer.getUint32(offset + 4, little);
   this._advance = 8;
-  return ((little ? b : a) << 32) + (little ? a : b);
+  return ((little ? b : a) * Math.pow(2, 32)) + (little ? a : b);
 };
 
 struct.types.uint64.set = function(offset, value, little) {


### PR DESCRIPTION
> Shift operators convert their operands to 32-bit integers in big-endian order and return a result of the same type as the left operand. The right operand should be less than 32, but if not only the
low five bits will be used.
_([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#<<_(Left_shift)))_

32 in binary is 100000, as a consequence using 32 as the right operand of a binary left shift operation is equivalent to using 0 (32's low five bits are 00000).

There is such an operation in Pebble.js's codebase, where it's implementing the 64-bit version of [`DataView.prototype.getUint32()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint32):

https://github.com/pebble/pebblejs/blob/78f2e104952fa8c63b141cdd9ffe81ca4e0c009f/src/js/lib/struct.js#L56-L62

This data type seems to be used only in one place: the millisecond-precise timestamp included in accelerometer samples:

https://github.com/pebble/pebblejs/blob/78f2e104952fa8c63b141cdd9ffe81ca4e0c009f/src/js/ui/simply-pebble.js#L538-L544

When reading accelerometer data, instead of getting valid timestamps that can convert to a date, you would get, before this fix, its lower half, in bits. For example, it is 21:07 on the day I am posting this, so the expected timestamp should be 1541279220000. When split in two 32-bit halves and put back together, it reads `(358 << 32) + 3680928032`. Unfortunately, the `<< 32` operation fails, and the returned timestamp is equal to `358 + 3680928032`.

The value returned by Pebble.js will be "lower half of binary timestamp + 358" for a period of `2^32` milliseconds (almost 50 days), then will become "lower half of binary timestamp + 359" for the following 50 days!

Even though this is a bug, the impact was minimal and the application was still able to collect accelerometer data points and place them relatively to each other on a time line. It wasn't able, however, to place accelerometer events on a real-life calendar date/time. This change fixes this.